### PR TITLE
Settings, Lore, and tracking for full bags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+
+lib/dannet/helpers.lua
+
+lib/Lemons/
+
+lib/LIP.lua

--- a/init.lua
+++ b/init.lua
@@ -403,7 +403,6 @@ local function lootCorpse(corpseID)
                 if corpseItem.Lore() then
                     local haveItem = mq.TLO.FindItem(('=%s'):format(corpseItem.Name()))() or -1
                     local haveItemBank = mq.TLO.FindItemBank(('=%s'):format(corpseItem.Name()))() or -1
-                  --  report('Have Banked:: '..tostring(haveItemBank)..' Have ON ME:: '..tostring(haveItem))                  ---- DEBUG LINE
                     if haveItem~= -1 or haveItemBank~= -1 or freeSpace <= loot.SaveBagSlots then
                         table.insert(loreItems, corpseItem.ItemLink('CLICKABLE')())
                         report('\ayLootNScoot::\arLORE ITEM:: \ayI Already have \ag'..corpseItem.Name()..'\ar ::LORE ITEM')

--- a/init.lua
+++ b/init.lua
@@ -111,10 +111,11 @@ local success, Write = pcall(require, 'lib.Write')
 if not success then printf('\arERROR: Write.lua could not be loaded\n%s\ax', Write) return end
 local eqServer = string.gsub(mq.TLO.EverQuest.Server(),' ','_')
 local eqChar = mq.TLO.Me.Name()
+local version = 1.2
 -- Public default settings, also read in from Loot.ini [Settings] section
 local loot = {
     logger = Write,
-    Version = "1.0",
+    Version = '"'..tostring(version)..'"',
     LootFile = mq.configDir .. '/Loot.ini',
     SettingsFile = mq.configDir.. '/LootNScoot_'..eqServer..'_'..eqChar..'.ini',
     AddNewSales = true,
@@ -141,6 +142,7 @@ local loot = {
     StackableOnly = false,
     CorpseRotTime = "440s",
     Terminate = true,
+    DoDestroy = false,
 }
 loot.logger.prefix = 'lootnscoot'
 
@@ -194,9 +196,8 @@ local function loadSettings()
     for i=1,keyCount do
         local key = iniSettings.Key.KeyAtIndex(i)()
         local value = iniSettings.Key(key).Value()
-        --print(key..' = '..value)
         if key == 'Version' then
-            loot[key] = value
+            loot[key] = tostring(value)
         elseif value == 'true' or value == 'false' then
             loot[key] = value == 'true' and true or false
         elseif tonumber(value) then
@@ -206,7 +207,12 @@ local function loadSettings()
         end
     end
     tmpDoLoot = loot.DoLoot
-    --print(tostring(loot.LootNoDrop))
+    shouldLootActions.Destroy = loot.DoDestroy or false
+    if tonumber(loot.Version) < tonumber(version) then
+        loot.Version = tostring(version)
+        print('Updating Settings File to Version '..tostring(version))
+        writeSettings()
+     end
 end
 
 local function checkCursor()

--- a/init.lua
+++ b/init.lua
@@ -152,10 +152,7 @@ local doSell = false
 local cantLootList = {}
 local cantLootID = 0
 local tmpDoLoot = false
-local questItemCount = {
-    name = '',
-    count = 0
-}
+
 -- Constants
 local spawnSearch = '%s radius %d zradius 50'
 -- If you want destroy to actually loot and destroy items, change Destroy=false to Destroy=true.
@@ -274,11 +271,6 @@ local function getRule(item)
         if not stackable and loot.StackableOnly then lootDecision = 'Ignore' end
         if loot.StackPlatValue > 0 and sellPrice*stackSize < loot.StackPlatValue then lootDecision = 'Ignore' end
         addRule(itemName, firstLetter, lootDecision)
-    end
-    if questItemCount.name == itemName then
-        if questItemCount.count < loot.QuestKeep then
-            questItemCount.count = questItemCount.count + 1
-        end
     end
     return lootData[firstLetter][itemName]
 end
@@ -408,9 +400,9 @@ local function lootCorpse(corpseID)
                 local stackable = corpseItem.Stackable()
                 local freeStack = corpseItem.FreeStack()
                 if corpseItem.Lore() then
-                    local haveItem = mq.TLO.FindItem(('=%s'):format(corpseItem.Name()))() or -1
-                    local haveItemBank = mq.TLO.FindItemBank(('=%s'):format(corpseItem.Name()))() or -1
-                    if haveItem~= -1 or haveItemBank~= -1 or freeSpace <= loot.SaveBagSlots then
+                    local haveItem = mq.TLO.FindItem(('=%s'):format(corpseItem.Name()))()
+                    local haveItemBank = mq.TLO.FindItemBank(('=%s'):format(corpseItem.Name()))()
+                    if haveItem or haveItemBank or freeSpace <= loot.SaveBagSlots then
                         table.insert(loreItems, corpseItem.ItemLink('CLICKABLE')())
                         report('\ayLootNScoot::\arLORE ITEM:: \ayI Already have \ag'..corpseItem.ItemLink('CLICKABLE')()..'\ar ::LORE ITEM')
                     elseif corpseItem.NoDrop() then
@@ -602,7 +594,7 @@ function loot.sellStuff()
     local newTotalPlat = mq.TLO.Me.Platinum() - totalPlat
     loot.logger.Info(string.format('Total plat value sold: \ag%s\ax', newTotalPlat))
     if mq.TLO.Me.FreeInventory() >= loot.SaveBagSlots and loot.WasLooting then
-        tmpDoLoot = true
+        tmpDoLoot, WasLooting = true, false
         writeSettings()
     end
 end

--- a/init.lua
+++ b/init.lua
@@ -379,6 +379,7 @@ local function lootCorpse(corpseID)
         report('My bags are full, I can\'t loot anymore! Turning OFF Looting until we sell.')
         tmpDoLoot = false
         loot.WasLooting = true
+        writeSettings()
         return
     end
     for i=1,3 do
@@ -600,7 +601,10 @@ function loot.sellStuff()
     if mq.TLO.Window('MerchantWnd').Open() then mq.cmd('/nomodkey /notify MerchantWnd MW_Done_Button leftmouseup') end
     local newTotalPlat = mq.TLO.Me.Platinum() - totalPlat
     loot.logger.Info(string.format('Total plat value sold: \ag%s\ax', newTotalPlat))
-    if mq.TLO.Me.FreeInventory() >= loot.SaveBagSlots and loot.WasLooting then tmpDoLoot = true end
+    if mq.TLO.Me.FreeInventory() >= loot.SaveBagSlots and loot.WasLooting then
+        tmpDoLoot = true
+        writeSettings()
+    end
 end
 
 -- BANKING

--- a/init.lua
+++ b/init.lua
@@ -207,12 +207,12 @@ local function loadSettings()
         end
     end
     tmpDoLoot = loot.DoLoot
-    shouldLootActions.Destroy = loot.DoDestroy or false
     if tonumber(loot.Version) < tonumber(version) then
         loot.Version = tostring(version)
         print('Updating Settings File to Version '..tostring(version))
         writeSettings()
-     end
+    end
+    shouldLootActions.Destroy = loot.DoDestroy
 end
 
 local function checkCursor()

--- a/init.lua
+++ b/init.lua
@@ -412,7 +412,7 @@ local function lootCorpse(corpseID)
                     local haveItemBank = mq.TLO.FindItemBank(('=%s'):format(corpseItem.Name()))() or -1
                     if haveItem~= -1 or haveItemBank~= -1 or freeSpace <= loot.SaveBagSlots then
                         table.insert(loreItems, corpseItem.ItemLink('CLICKABLE')())
-                        report('\ayLootNScoot::\arLORE ITEM:: \ayI Already have \ag'..corpseItem.Name()..'\ar ::LORE ITEM')
+                        report('\ayLootNScoot::\arLORE ITEM:: \ayI Already have \ag'..corpseItem.ItemLink('CLICKABLE')()..'\ar ::LORE ITEM')
                     elseif corpseItem.NoDrop() then
                             if loot.LootNoDrop then 
                                 lootItem(i, getRule(corpseItem), 'leftmouseup')
@@ -420,7 +420,7 @@ local function lootCorpse(corpseID)
                                 table.insert(noDropItems, corpseItem.ItemLink('CLICKABLE')())
                             end
                     else
-                        report('\ayLootNScoot::\arLORE ITEM:: \ayLooting Lore Item::\ag '..corpseItem.Name())
+                        report('\ayLootNScoot::\arLORE ITEM:: \ayLooting Lore Item::\ag '..corpseItem.ItemLink('CLICKABLE')())
                         lootItem(i, getRule(corpseItem), 'leftmouseup')
                     end
                 elseif corpseItem.NoDrop() then


### PR DESCRIPTION
* split the settings out of the loot.ini file, moved it to LootNScoot_Server_Name_CharName.ini
* Added a flag that we save to settings WasLooting
This is used for when we have full bags. 
* Added local tmpDoLoot stores ini DoLoot value so we we have a flag to change. 
* if Bags are full we set WasLooting to true and tmpDoLoot to false. until we have more bag space.
* Saving this WasLooting setting will allow keeping track if issuing /lua run lootnscoot once comamnds.
* This is helpful if you want to integrate into a macro like Kissassist. I actually use this method with KissCharm.
* Added Nil check for lore looting, since we are looking at strings 'nil' is a valid result and it skips looting.
* Added some reporting for lore items. 
