### PR TITLE
Quest Items

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -752,7 +752,7 @@ end
 init({...})
 
 while not loot.Terminate do
-    if loot.DoLoot then loot.lootMobs() end
+    if loot.DoLoot and not areFull then loot.lootMobs() end
     if doSell then loot.sellStuff() doSell = false end
     mq.delay(1000)
 end

--- a/init.lua
+++ b/init.lua
@@ -297,7 +297,7 @@ local function getRule(item)
                 return 'Keep'
             else
                 report("\awIgnoring Quest Item:\ag %s \awCount:\ar %s \awof\ar %s",itemName,tostring(countHave),qKeep)
-                return 'Ignore'
+                return 'Destroy'
             end
         end
     end
@@ -390,6 +390,7 @@ local function lootItem(index, doWhat, button)
     if mq.TLO.Cursor() then checkCursor() end
     mq.delay(10)
     CheckBags()
+
     if areFull then report('My bags are full, I can\'t loot anymore! Turning OFF Looting until we sell.') end
 end
 

--- a/init.lua
+++ b/init.lua
@@ -743,7 +743,7 @@ local function init(args)
     else
         loadSettings()
     end
-
+    CheckBags()
     setupEvents()
     setupBinds()
     processArgs(args)
@@ -752,7 +752,6 @@ end
 init({...})
 
 while not loot.Terminate do
-    CheckBags()
     if loot.DoLoot then loot.lootMobs() end
     if doSell then loot.sellStuff() doSell = false end
     mq.delay(1000)


### PR DESCRIPTION
* Added setting LootQuest default false 
     * If set to true, and an item is marked as Quest in the loot.ini we check for a quantity 
     * If the entry is listed like itemname=Quest|5 then the quantity will be 5 that we loot. if no quantity is set and its just Quest, we will default to the QuestKeep amount. 
     * Will report the count if reportloot is on. 
     * Stops looting that items and switches to Ignore once you reach your qty. 
     * Checks both bank and inventory to get a total count.

* Cleaned up some of the bags full code, no need for tamp variables when we can just store BagsFull = true or false. 
* Renamed WasLooting to BagsFull logically makes more sense.
* Version bump to update Settings ini's with new settings. *This happens automatically and preserves your old settings*