### PR TITLE
Alwaysdestroy

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -386,7 +386,7 @@ local function lootItem(index, doWhat, button, qKeep)
     mq.delay(1) -- force next frame
     -- The loot window closes if attempting to loot a lore item you already have, but lore should have already been checked for
     if not mq.TLO.Window('LootWnd').Open() then return end
-    if doWhat == 'Destroy' then mq.cmd('/destroy') end
+    if doWhat == 'Destroy' and mq.TLO.Cursor.ID() == corpseItemID then mq.cmd('/destroy') end
     checkCursor()
     if qKeep > 0 and doWhat == 'Keep' then
         local countHave = mq.TLO.FindItemCount(string.format("%s",itemName))() + mq.TLO.FindItemBankCount(string.format("%s",itemName))()
@@ -631,7 +631,6 @@ function loot.sellStuff()
     if mq.TLO.Window('MerchantWnd').Open() then mq.cmd('/nomodkey /notify MerchantWnd MW_Done_Button leftmouseup') end
     local newTotalPlat = mq.TLO.Me.Platinum() - totalPlat
     report('Total plat value sold: \ag%s\ax', newTotalPlat)
-    loot.logger.Info(string.format('Total plat value sold: \ag%s\ax', newTotalPlat))
     CheckBags()
 end
 


### PR DESCRIPTION
* Added Sales reporting. to see group sales totals from driver.
* All reporting should now use Item Links.
* Tweaked the settings layout to group settings better on initial creation.
* Moved destroy command farther down the decision making as it appears to not need confirmation windows even when set to always require them.  And Causes delays or skipped items it set before the confirmation checks.
* Added a setting to always destroy instead of Ignore. 

  * **WILL NOT** Destroy Lore Items Ignored because you already have one.
  * **WILL DESTROY** Quest Items over Max, and Items Marked Ignore in config file
  * Requires **DoDestroy = true**, otherwise just Ignores Item.

  * WARNING!! Recommend only turning this on for one character. Handy for cleaning up extra quest items after you hit the max while clearing the instance. 
