### PR TITLE
tribute_stuff

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -68,7 +68,7 @@ The script will setup a bind for "/lootutils":
             - Keep
             - Bank
             - Sell
-            - Tribute (Not Implemented)
+            - Tribute
             - Ignore
             - Destroy
             - Quest|#
@@ -81,7 +81,7 @@ The script will setup a bind for "/lootutils":
         Mark all tradeskill items in inventory as Bank
 
 If running in standalone mode, the bind also supports:
-    /lootutils sell
+    /lootutils sellstuff
         Runs lootutils.sellStuff() one time
 
 The following events are used:
@@ -350,13 +350,8 @@ end
 local function commandHandler(...)
     local args = {...}
     if #args == 1 then
-        if args[1] == 'sell' and not loot.Terminate then
-            if not mq.TLO.Cursor() then
-                doSell = true
-            else
-                addRule(mq.TLO.Cursor(), mq.TLO.Cursor():sub(1,1), 'Sell')
-                loot.logger.Info(string.format("Setting \ay%s\ax to \ay%s\ax", mq.TLO.Cursor(), 'Sell'))
-            end
+        if args[1] == 'sellstuff' and not loot.Terminate then
+            doSell = true
         elseif args[1] == 'reload' then
             lootData = {}
             loadSettings()
@@ -391,6 +386,14 @@ local function commandHandler(...)
         if args[1] == 'quest' and mq.TLO.Cursor() then
             addRule(mq.TLO.Cursor(),mq.TLO.Cursor():sub(1,1), 'Quest|'..args[2])
             loot.logger.Info(string.format("Setting \ay%s\ax to \ayQuest|%s\ax", mq.TLO.Cursor(), args[2]))
+        elseif validActions[args[1]] and args[2] ~= 'NULL' then
+            addRule(args[2], args[2]:sub(1,1), validActions[args[1]])
+            loot.logger.Info(string.format("Setting \ay%s\ax to \ay%s\ax", args[2], validActions[args[1]]))
+        end
+    elseif #args == 3 then
+        if validActions[args[1]] and args[2] ~= 'NULL' then
+            addRule(args[2], args[2]:sub(1,1), validActions[args[1]]..'|'..args[3])
+            loot.logger.Info(string.format("Setting \ay%s\ax to \ay%s|%s\ax", args[2], validActions[args[1]], args[3]))
         end
     end
 end

--- a/init.lua
+++ b/init.lua
@@ -105,60 +105,63 @@ There is also no flag for combat looting. It will only loot if no mobs are withi
 
 ]]
 
+
 ---@type Mq
 local mq = require 'mq'
 local success, Write = pcall(require, 'lib.Write')
 if not success then printf('\arERROR: Write.lua could not be loaded\n%s\ax', Write) return end
 local eqServer = string.gsub(mq.TLO.EverQuest.Server(),' ','_')
 local eqChar = mq.TLO.Me.Name()
-local version = 1.4
+local version = 1.5
 -- Public default settings, also read in from Loot.ini [Settings] section
 local loot = {
     logger = Write,
     Version = '"'..tostring(version)..'"',
     LootFile = mq.configDir .. '/Loot.ini',
     SettingsFile = mq.configDir.. '/LootNScoot_'..eqServer..'_'..eqChar..'.ini',
-    GlobalLootOn = true,
-    CombatLooting = false,
-    CorpseRadius = 100,
-    MobsTooClose = 40,
-    SaveBagSlots = 3,
-    MinSellPrice = -1,
-    StackPlatValue = 0,
-    StackableOnly = false,
-    DoLoot = true,
-    LootForage = true,
-    LootNoDrop = false,
-    LootQuest = false,
-    DoDestroy = false,
-    AlwaysDestroy = false,
-    QuestKeep = 10,
-    LootChannel = "dgt",
-    ReportLoot = true,
-    SpamLootInfo = false,
-    LootForageSpam = false,
-    AddNewSales = true,
+    GlobalLootOn = true,        -- Enable Global Loot Items.
+    CombatLooting = false,      -- Enables looting during combat. Not recommended on the MT
+    CorpseRadius = 100,         -- Radius to activly loot corpses
+    MobsTooClose = 40,          -- Don't loot if mobs are in this range.
+    SaveBagSlots = 3,           -- Number of bag slots you would like to keep empty at all times. Stop looting if we hit this number
+    TributeKeep = false,        -- Keep items flagged Tribute
+    MinTributeValue = 100,      -- Minimun Tribute points to keep item if TributeKeep is enabled.
+    MinSellPrice = -1,          -- Minimum Sell price to keep item. -1 = any
+    StackPlatValue = 0,         -- Minimum sell value for full stack
+    StackableOnly = false,      -- Only loot stackable items
+    AlwaysEval = false,         -- Re-Evaluate all *Non Quest* items. useful to update loot.ini after changing min sell values.
+    BankTradeskills = true,     -- Toggle flagging Tradeskill items as Bank or not.
+    DoLoot = true,              -- Enable auto looting in standalone mode
+    LootForage = true,          -- Enable Looting of Foraged Items
+    LootNoDrop = false,         -- Enable Looting of NoDrop items.
+    LootQuest = false,          -- Enable Looting of Items Marked 'Quest', requires LootNoDrop on to loot NoDrop quest items
+    DoDestroy = false,          -- Enable Destroy functionality. Otherwise 'Destroy' acts as 'Ignore'
+    AlwaysDestroy = false,      -- Always Destroy items to clean corpese Will Destroy Non-Quest items marked 'Ignore' items REQUIRES DoDestroy set to true
+    QuestKeep = 10,             -- Default number to keep if item not set using Quest|# format.
+    LootChannel = "dgt",        -- Channel we report loot to.
+    ReportLoot = true,          -- Report loot items to group or not.
+    SpamLootInfo = false,       -- Echo Spam for Looting
+    LootForageSpam = false,     -- Echo spam for Foraged Items
+    AddNewSales = true,         -- Adds 'Sell' Flag to items automatically if you sell them while the script is running.
     GMLSelect = true,
-    ExcludeBag1 = "Extraplanar Trade Satchel",
+    ExcludeBag1 = "Extraplanar Trade Satchel", -- Name of Bag to ignore items in when selling
     NoDropDefaults = "Quest|Keep|Ignore",
-    LootLagDelay = 0,
-    CorpseRotTime = "440s",
+    LootLagDelay = 0,           -- not implimented yet
+    CorpseRotTime = "440s",     -- not implimented yet
     Terminate = true,
 }
 loot.logger.prefix = 'lootnscoot'
 
 -- Internal settings
-local lootData = {}
-local doSell = false
-local cantLootList = {}
+local lootData, cantLootList = {}, {}
+local doSell, doTribute, areFull = false, false, false
 local cantLootID = 0
-local areFull = false
 -- Constants
 local spawnSearch = '%s radius %d zradius 50'
--- If you want destroy to actually loot and destroy items, change Destroy=false to Destroy=true.
+-- If you want destroy to actually loot and destroy items, change DoDestroy=false to DoDestroy=true in the Settings Ini.
 -- Otherwise, destroy behaves the same as ignore.
-local shouldLootActions = {Keep=true, Bank=true, Sell=true, Destroy=false, Ignore=false}
-local validActions = {keep='Keep',bank='Bank',sell='Sell',ignore='Ignore',destroy='Destroy'}
+local shouldLootActions = {Keep=true, Bank=true, Sell=true, Destroy=false, Ignore=false, Tribute=false}
+local validActions = {keep='Keep',bank='Bank',sell='Sell',ignore='Ignore',destroy='Destroy',quest='Quest', tribute='Tribute'}
 local saveOptionTypes = {string=1,number=1,boolean=1}
 
 -- FORWARD DECLARATIONS
@@ -209,6 +212,7 @@ local function loadSettings()
         writeSettings()
     end
     shouldLootActions.Destroy = loot.DoDestroy
+    shouldLootActions.Tribute = loot.TributeKeep
 end
 
 local function checkCursor()
@@ -267,18 +271,34 @@ local function getRule(item)
     local tradeskill = item.Tradeskills()
     local sellPrice = item.Value() and item.Value()/1000 or 0
     local stackable = item.Stackable()
+    local tributeValue = item.Tribute()
     local firstLetter = itemName:sub(1,1):upper()
     local stackSize = item.StackSize()
     local countHave = mq.TLO.FindItemCount(string.format("%s",itemName))() + mq.TLO.FindItemBankCount(string.format("%s",itemName))()
     local qKeep = 0
-
+    
     lootData[firstLetter] = lootData[firstLetter] or {}
     lootData[firstLetter][itemName] = lootData[firstLetter][itemName] or lookupIniLootRule(firstLetter, itemName)
+    -- Re-Evaluate the settings if AlwaysEval is on. Items that do not meet the Characters settings are reset to NUll and re-evaluated as if they were new items.
+    if loot.AlwaysEval then
+        local oldDecision = lootData[firstLetter][itemName] -- whats on file
+        local resetDecision = 'NULL'
+        if string.find(oldDecision,'Quest') or oldDecision == 'Keep' or oldDecision == 'Destroy' then resetDecision = oldDecision end
+        -- If sell price changed and item doesn't meet the new value re-evalute it otherwise keep it set to sell
+        if oldDecision == 'Sell' and not stackable and sellPrice >= loot.MinSellPrice then resetDecision = oldDecision end
+        -- -- Do the same for stackable items.
+        if (oldDecision == 'Sell' and stackable) and (sellPrice*stackSize >= loot.StackPlatValue) then resetDecision = oldDecision end
+        -- if banking tradeskills settings changed re-evaluate
+        if oldDecision == 'Bank' and tradeskill and loot.BankTradeskills then resetDecision = oldDecision end
+        lootData[firstLetter][itemName] = resetDecision -- pass value on to next check. Items marked 'NULL' will be treated as new and evaluated properly.
+    end
     if lootData[firstLetter][itemName] == 'NULL' then
-        if tradeskill then lootDecision = 'Bank' end
-        if sellPrice < loot.MinSellPrice then lootDecision = 'Ignore' end
+        if tradeskill and loot.BankTradeskills then lootDecision = 'Bank' end
+        if not stackable and sellPrice < loot.MinSellPrice then lootDecision = 'Ignore' end -- added stackable check otherwise it would stay set to Ignore when checking Stackable items in next steps.
         if not stackable and loot.StackableOnly then lootDecision = 'Ignore' end
-        if loot.StackPlatValue > 0 and sellPrice*stackSize < loot.StackPlatValue then lootDecision = 'Ignore' end
+        if (stackable and loot.StackPlatValue > 0) and (sellPrice*stackSize < loot.StackPlatValue) then lootDecision = 'Ignore' end
+        -- set Tribute flag if tribute value is greater than minTributeValue and the sell price is less than min sell price or has no value
+        if tributeValue >= loot.MinTributeValue and (sellPrice < loot.MinSellPrice or sellPrice == 0) then lootDecision = 'Tribute' end
         addRule(itemName, firstLetter, lootDecision)
     end
     -- Check if item marked Quest
@@ -328,26 +348,38 @@ local function commandHandler(...)
     local args = {...}
     if #args == 1 then
         if args[1] == 'sell' and not loot.Terminate then
-            doSell = true
+            if not mq.TLO.Cursor() then
+                doSell = true
+            else
+                addRule(mq.TLO.Cursor(), mq.TLO.Cursor():sub(1,1), 'Sell')
+                loot.logger.Info(string.format("Setting \ay%s\ax to \ay%s\ax", mq.TLO.Cursor(), 'Sell'))
+            end
         elseif args[1] == 'reload' then
             lootData = {}
-            loot.logger.Info("Reloaded Loot File")
+            loadSettings()
+            loot.Terminate = false
+            loot.logger.Info("Reloaded Settings And Loot Files")
         elseif args[1] == 'bank' then
             loot.bankStuff()
+        elseif args[1] == 'tribute' then
+            if not mq.TLO.Cursor() then
+                doTribute = true
+            else
+                addRule(mq.TLO.Cursor(), mq.TLO.Cursor():sub(1,1), 'Tribute')
+                loot.logger.Info(string.format("Setting \ay%s\ax to \ay%s\ax", mq.TLO.Cursor(), 'Tribute'))
+            end
         elseif args[1] == 'loot' then
             loot.lootMobs()
         elseif args[1] == 'tsbank' then
             loot.markTradeSkillAsBank()
+        elseif validActions[args[1]] and mq.TLO.Cursor() then
+            addRule(mq.TLO.Cursor(), mq.TLO.Cursor():sub(1,1), validActions[args[1]])
+            loot.logger.Info(string.format("Setting \ay%s\ax to \ay%s\ax", mq.TLO.Cursor(), validActions[args[1]]))
         end
     elseif #args == 2 then
-        if validActions[args[1]] and args[2] ~= 'NULL' then
-            addRule(args[2], args[2]:sub(1,1), validActions[args[1]])
-            loot.logger.Info(string.format("Setting \ay%s\ax to \ay%s\ax", args[2], validActions[args[1]]))
-        end
-    elseif #args == 3 then
-        if args[1] == 'quest' and args[2] ~= 'NULL' then
-            addRule(args[2], args[2]:sub(1,1), 'Quest|'..args[3])
-            loot.logger.Info(string.format("Setting \ay%s\ax to \ayQuest|%s\ax", args[2], args[3]))
+        if args[1] == 'quest' and mq.TLO.Cursor() then
+            addRule(mq.TLO.Cursor(),mq.TLO.Cursor():sub(1,1), 'Quest|'..args[2])
+            loot.logger.Info(string.format("Setting \ay%s\ax to \ayQuest|%s\ax", mq.TLO.Cursor(), args[2]))
         end
     end
 end
@@ -378,7 +410,7 @@ local function lootItem(index, doWhat, button, qKeep)
     local itemLink = corpseItem.ItemLink('CLICKABLE')()
     mq.cmdf('/nomodkey /shift /itemnotify loot%s %s', index, button)
     -- Looting of no drop items is currently disabled with no flag to enable anyways
-    -- added check to make sure the cursor isn't empty so we can exit the pause early.-- or not mq.TLO.Corpse.Item(index).NoDrop()    
+    -- added check to make sure the cursor isn't empty so we can exit the pause early.-- or not mq.TLO.Corpse.Item(index).NoDrop()
     mq.delay(1) -- for good measure.
     mq.delay(5000, function() return mq.TLO.Window('ConfirmationDialogBox').Open() or mq.TLO.Cursor() == nil end)
     if mq.TLO.Window('ConfirmationDialogBox').Open() then mq.cmd('/nomodkey /notify ConfirmationDialogBox Yes_Button leftmouseup') end
@@ -422,6 +454,7 @@ local function lootCorpse(corpseID)
     loot.logger.Debug(('Loot window open. Items: %s'):format(items))
     local corpseName = mq.TLO.Corpse.Name()
     if mq.TLO.Window('LootWnd').Open() and items > 0 then
+        if mq.TLO.Corpse.DisplayName() == mq.TLO.Me.DisplayName() then mq.cmd('/lootall') return end -- if its our own corpse just loot it.
         local noDropItems = {}
         local loreItems = {}
         for i=1,items do
@@ -439,22 +472,22 @@ local function lootCorpse(corpseID)
                         table.insert(loreItems, itemLink)
                         lootItem(i,'Ignore','leftmouseup', 0)
                     elseif corpseItem.NoDrop() then
-                            if loot.LootNoDrop then
-                                lootItem(i, itemRule, 'leftmouseup', qKeep)
-                            else
-                                table.insert(noDropItems, itemLink)
-                                lootItem(i,'Ignore','leftmouseup',0)
-                            end
-                    else
-                        lootItem(i, itemRule, 'leftmouseup', qKeep)
-                    end
-                elseif corpseItem.NoDrop() then
                         if loot.LootNoDrop then
                             lootItem(i, itemRule, 'leftmouseup', qKeep)
                         else
                             table.insert(noDropItems, itemLink)
                             lootItem(i,'Ignore','leftmouseup',0)
                         end
+                    else
+                        lootItem(i, itemRule, 'leftmouseup', qKeep)
+                    end
+                elseif corpseItem.NoDrop() then
+                    if loot.LootNoDrop then
+                        lootItem(i, itemRule, 'leftmouseup', qKeep)
+                    else
+                        table.insert(noDropItems, itemLink)
+                        lootItem(i,'Ignore','leftmouseup',0)
+                    end
                 elseif freeSpace > loot.SaveBagSlots or (stackable and freeStack > 0) then
                     lootItem(i, itemRule, 'leftmouseup', qKeep)
                 end
@@ -549,7 +582,7 @@ local function goToVendor()
         return false
     end
     local vendorName = mq.TLO.Target.CleanName()
-
+    
     loot.logger.Info('Doing business with '..vendorName)
     if mq.TLO.Target.Distance() > 15 then
         navToID(mq.TLO.Target.ID())
@@ -561,8 +594,9 @@ local function openVendor()
     loot.logger.Debug('Opening merchant window')
     mq.cmd('/nomodkey /click right target')
     loot.logger.Debug('Waiting for merchant window to populate')
-    mq.delay(1000, function() return mq.TLO.Window('MerchantWnd').Open() end)
-    if not mq.TLO.Window('MerchantWnd').Open() then return false end
+    mq.delay(1000, function() return mq.TLO.Window('MerchantWnd').Open() or mq.TLO.Window('TributeMasterWnd').Open() end)
+    if not mq.TLO.Window('MerchantWnd').Open() or mq.TLO.Window('TributeMasterWnd').Open() then return false end
+    if mq.TLO.Window('TributeMasterWnd').Open() then return true end
     mq.delay(5000, function() return mq.TLO.Merchant.ItemsReceived() end)
     return mq.TLO.Merchant.ItemsReceived()
 end
@@ -593,7 +627,7 @@ function loot.sellStuff()
         if not goToVendor() then return end
         if not openVendor() then return end
     end
-
+    
     local totalPlat = mq.TLO.Me.Platinum()
     -- sell any top level inventory items that are marked as well, which aren't bags
     for i=1,10 do
@@ -631,6 +665,61 @@ function loot.sellStuff()
     if mq.TLO.Window('MerchantWnd').Open() then mq.cmd('/nomodkey /notify MerchantWnd MW_Done_Button leftmouseup') end
     local newTotalPlat = mq.TLO.Me.Platinum() - totalPlat
     report('Total plat value sold: \ag%s\ax', newTotalPlat)
+    CheckBags()
+end
+
+-- TRIBUTEING
+
+local function tributeToVendor(itemToTrib)
+    if NEVER_SELL[itemToTrib.Name()] then return end
+    while mq.TLO.FindItemCount('='..itemToTrib.Name())() > 0 do
+        if mq.TLO.Window('TributeMasterWnd').Open() then
+            loot.logger.Info('Tributeing '..itemToTrib.Name())
+            mq.cmdf('/nomodkey /itemnotify "%s" leftmouseup', itemToTrib.Name())
+            mq.delay(1) -- progress frame
+            mq.delay(1000, function() return mq.TLO.Window('TributeMasterWnd').Child('TMW_ValueLabel').Text() == itemToTrib.Tribute() end)
+            if mq.TLO.Window('TributeMasterWnd').Child('TMW_DonateButton').Enabled() then mq.TLO.Window('TributeMasterWnd').Child('TMW_DonateButton').LeftMouseUp() end
+            mq.delay(1)
+            mq.delay(1000, function() return not mq.TLO.Window('TributeMasterWnd').Child('TMW_DonateButton').Enabled() end)
+            mq.delay(1000) -- This delay is necessary because there is seemingly a delay between donating and selecting the next item.
+        end
+    end
+end
+
+function loot.tributeStuff()
+    if not mq.TLO.Window('TributeMasterWnd').Open() then
+        if not goToVendor() then return end
+        if not openVendor() then return end
+    end
+    -- Check top level inventory items that are marked as well, which aren't bags
+    for i=1,10 do
+        local bagSlot = mq.TLO.InvSlot('pack'..i).Item
+        if bagSlot.Container() == 0 then
+            if bagSlot.ID() then
+                local itemToTrib = bagSlot
+                local tribRule = getRule(bagSlot)
+                if tribRule == 'Tribute' then tributeToVendor(itemToTrib) end
+            end
+        end
+    end
+    -- Check items in bags which are marked as tribute
+    for i=1,10 do
+        local bagSlot = mq.TLO.InvSlot('pack'..i).Item
+        local containerSize = bagSlot.Container()
+        if containerSize and containerSize > 0 then
+            for j=1,containerSize do
+                local itemToTrib = bagSlot.Item(j)
+                if itemToTrib.ID() then
+                    local tribRule = getRule(itemToTrib)
+                    if tribRule == 'Tribute' then
+                        tributeToVendor(itemToTrib)
+                    end
+                end
+            end
+        end
+    end
+    mq.flushevents('Tribute')
+    if mq.TLO.Window('TributeMasterWnd').Open() then mq.TLO.Window('TributeMasterWnd').DoClose() end
     CheckBags()
 end
 
@@ -723,8 +812,8 @@ function eventForage()
                 mq.cmd('/destroy')
                 mq.delay(500)
             end
-        -- will a lore item we already have even show up on cursor?
-        -- free inventory check won't cover an item too big for any container so may need some extra check related to that?
+            -- will a lore item we already have even show up on cursor?
+            -- free inventory check won't cover an item too big for any container so may need some extra check related to that?
         elseif (shouldLootActions[ruleAction] or currentItemAmount < ruleAmount) and (not cursorItem.Lore() or currentItemAmount == 0) and (mq.TLO.Me.FreeInventory() or (cursorItem.Stackable() and cursorItem.FreeStack())) then
             if loot.LootForageSpam then loot.logger.Info('Keeping foraged item '..foragedItem) end
             mq.cmd('/autoinv')
@@ -768,6 +857,8 @@ init({...})
 while not loot.Terminate do
     if loot.DoLoot and not areFull then loot.lootMobs() end
     if doSell then loot.sellStuff() doSell = false end
+    if doTribute then loot.tributeStuff() doTribute = false end
+    mq.doevents()
     mq.delay(1000)
 end
 

--- a/init.lua
+++ b/init.lua
@@ -143,9 +143,9 @@ local loot = {
     SpamLootInfo = false,       -- Echo Spam for Looting
     LootForageSpam = false,     -- Echo spam for Foraged Items
     AddNewSales = true,         -- Adds 'Sell' Flag to items automatically if you sell them while the script is running.
-    GMLSelect = true,
+    GMLSelect = true,           -- not implimented yet
     ExcludeBag1 = "Extraplanar Trade Satchel", -- Name of Bag to ignore items in when selling
-    NoDropDefaults = "Quest|Keep|Ignore",
+    NoDropDefaults = "Quest|Keep|Ignore",   -- not implimented yet
     LootLagDelay = 0,           -- not implimented yet
     CorpseRotTime = "440s",     -- not implimented yet
     Terminate = true,
@@ -265,6 +265,7 @@ local function report(message, ...)
     end
 end
 
+---@return string,number
 local function getRule(item)
     local itemName = item.Name()
     local lootDecision = 'Keep'
@@ -275,8 +276,8 @@ local function getRule(item)
     local firstLetter = itemName:sub(1,1):upper()
     local stackSize = item.StackSize()
     local countHave = mq.TLO.FindItemCount(string.format("%s",itemName))() + mq.TLO.FindItemBankCount(string.format("%s",itemName))()
-    local qKeep = 0
-    
+    local qKeep = '0'
+
     lootData[firstLetter] = lootData[firstLetter] or {}
     lootData[firstLetter][itemName] = lootData[firstLetter][itemName] or lookupIniLootRule(firstLetter, itemName)
     -- Re-Evaluate the settings if AlwaysEval is on. Items that do not meet the Characters settings are reset to NUll and re-evaluated as if they were new items.
@@ -308,10 +309,10 @@ local function getRule(item)
         if loot.LootQuest then
             --look to see if Quantity attached to Quest|qty
             local _, position = string.find(lootData[firstLetter][itemName], '|')
-            if position then qKeep = tonumber(string.sub(lootData[firstLetter][itemName], position + 1)) else qKeep = 0 end
+            if position then qKeep = string.sub(lootData[firstLetter][itemName], position + 1) else qKeep = '0' end
             -- if Quantity is tied to the entry then use that otherwise use default Quest Keep Qty.
-            if qKeep == 0 then
-                qKeep = loot.QuestKeep
+            if qKeep == '0' then
+                qKeep = tostring(loot.QuestKeep)
             end
             -- If we have less than we want to keep loot it.
             if countHave < tonumber(qKeep) then
@@ -319,7 +320,7 @@ local function getRule(item)
             end
             if loot.AlwaysDestroy and qVal == 'Ignore' then qVal = 'Destroy' end
         end
-        return qVal,qKeep
+        return qVal,tonumber(qKeep) or 0
     end
     if loot.AlwaysDestroy and lootData[firstLetter][itemName] == 'Ignore' then return 'Destroy',0 end
     return lootData[firstLetter][itemName],0
@@ -582,7 +583,7 @@ local function goToVendor()
         return false
     end
     local vendorName = mq.TLO.Target.CleanName()
-    
+
     loot.logger.Info('Doing business with '..vendorName)
     if mq.TLO.Target.Distance() > 15 then
         navToID(mq.TLO.Target.ID())
@@ -627,7 +628,7 @@ function loot.sellStuff()
         if not goToVendor() then return end
         if not openVendor() then return end
     end
-    
+
     local totalPlat = mq.TLO.Me.Platinum()
     -- sell any top level inventory items that are marked as well, which aren't bags
     for i=1,10 do

--- a/init.lua
+++ b/init.lua
@@ -402,6 +402,8 @@ local function commandHandler(...)
             loot.processItems('Cleanup')
         elseif args[1] == 'gui' then
             guiLoot.shouldDrawGUI = not guiLoot.shouldDrawGUI
+        elseif args[1] == 'hidenames' then
+            guiLoot.hideNames = not guiLoot.hideNames
         elseif args[1] == 'config' then
             local confReport = string.format("\ayLoot N Scoot Settings\ax")
             for key, value in pairs(loot) do
@@ -766,10 +768,10 @@ local function tributeToVendor(itemToTrib,bag,slot)
         report('\ayTributing \at%s \axfor\ag %s \axpoints!',itemToTrib.Name(),itemToTrib.Tribute())
         mq.cmdf('/shift /itemnotify in pack%s %s leftmouseup', bag, slot)
         mq.delay(1) -- progress frame
-        mq.delay(2000, function() return mq.TLO.Window('TributeMasterWnd').Child('TMW_ValueLabel').Text() == itemToTrib.Tribute() end)
+        mq.delay(5000, function() return mq.TLO.Window('TributeMasterWnd').Child('TMW_ValueLabel').Text() == itemToTrib.Tribute() end)
         if mq.TLO.Window('TributeMasterWnd').Child('TMW_DonateButton').Enabled() then mq.TLO.Window('TributeMasterWnd').Child('TMW_DonateButton').LeftMouseUp() end
         mq.delay(1)
-        mq.delay(2000, function() return not mq.TLO.Window('TributeMasterWnd').Child('TMW_DonateButton').Enabled() end)
+        mq.delay(5000, function() return not mq.TLO.Window('TributeMasterWnd').Child('TMW_DonateButton').Enabled() end)
         mq.delay(1000) -- This delay is necessary because there is seemingly a delay between donating and selecting the next item.
     end
 end

--- a/init.lua
+++ b/init.lua
@@ -180,7 +180,7 @@ local NEVER_SELL = {['Diamond Coin']=true, ['Celestial Crest']=true, ['Gold Coin
 
 -- FORWARD DECLARATIONS
 
-local eventForage, eventSell, eventCantLoot, eventTribute
+local eventForage, eventSell, eventCantLoot, eventTribute, eventNoSlot
 
 -- UTILITIES
 
@@ -375,6 +375,7 @@ end
 
 local function setupEvents()
     mq.event("CantLoot", "#*#may not loot this corpse#*#", eventCantLoot)
+    mq.event("NoSlot", "#*#There are no slots of the held item in your inventory#*#", eventNoSlot)
     mq.event("Sell", "#*#You receive#*# for the #1#(s)#*#", eventSell)
     if loot.LootForage then
         mq.event("ForageExtras", "Your forage mastery has enabled you to find something else!", eventForage)
@@ -401,7 +402,7 @@ local function commandHandler(...)
         elseif args[1] == 'cleanup' then
             loot.processItems('Cleanup')
         elseif args[1] == 'gui' then
-            guiLoot.shouldDrawGUI = not guiLoot.shouldDrawGUI
+            guiLoot.openGUI = not guiLoot.openGUI
         elseif args[1] == 'hidenames' then
             guiLoot.hideNames = not guiLoot.hideNames
         elseif args[1] == 'config' then
@@ -464,6 +465,14 @@ end
 
 function eventCantLoot()
     cantLootID = mq.TLO.Target.ID()
+end
+
+function eventNoSlot()
+    -- we don't have a slot big enough for the item on cursor. Dropping it to the ground. 
+    local cantLootItemName = mq.TLO.Cursor()
+    mq.cmd('/drop')
+    mq.delay(1)
+    report("\ay[WARN]\arI can't loot %s, dropping it on the ground!\ax", cantLootItemName)
 end
 
 ---@param index number @The current index we are looking at in loot window, 1-based.

--- a/init.lua
+++ b/init.lua
@@ -694,6 +694,27 @@ end
 
 -- TRIBUTEING
 
+local function AreBagsOpen()
+    local total = {
+    bags = 0,
+    open = 0,
+    }
+    for i = 23, 32 do
+    local slot = mq.TLO.Me.Inventory(i)
+        if slot and slot.Container() and slot.Container() > 0 then
+            total.bags = total.bags + 1
+            if slot.Open() then
+                total.open = total.open + 1
+            end
+        end
+    end
+    if total.bags == total.open then
+        return true
+    else
+        return false
+    end
+end
+
 function eventTribute(line, itemName)
     local firstLetter = itemName:sub(1,1):upper()
     if lootData[firstLetter] and lootData[firstLetter][itemName] == 'Tribute' then return end
@@ -732,6 +753,10 @@ function loot.tributeStuff()
         if not goToVendor() then return end
         if not openTribMaster() then return end
     end
+    mq.cmd('/keypress OPEN_INV_BAGS')
+    -- tributes requires the bags to be open
+    mq.delay(1000, AreBagsOpen)
+    mq.delay(1)
     local flag = false
     if loot.AlwaysEval then flag ,loot.AlwaysEval = true,false end
     -- Check top level inventory items that are marked as well, which aren't bags
@@ -763,6 +788,7 @@ function loot.tributeStuff()
     mq.flushevents('Tribute')
     if mq.TLO.Window('TributeMasterWnd').Open() then mq.TLO.Window('TributeMasterWnd').DoClose() end
     CheckBags()
+    mq.cmd('/keypress CLOSE_INV_BAGS')
 end
 
 -- BANKING

--- a/init.lua
+++ b/init.lua
@@ -83,6 +83,8 @@ The script will setup a bind for "/lootutils":
 If running in standalone mode, the bind also supports:
     /lootutils sellstuff
         Runs lootutils.sellStuff() one time
+    /lootutils tributestuff
+        Runs lootutils.tributeStuff() one time
 
 The following events are used:
     - eventCantLoot - #*#may not loot this corpse#*#
@@ -367,13 +369,8 @@ local function commandHandler(...)
                 end
             end
             loot.logger.Info(confReport)
-        elseif args[1] == 'tribute' then
-            if not mq.TLO.Cursor() then
+        elseif args[1] == 'tributestuff' then
                 doTribute = true
-            else
-                addRule(mq.TLO.Cursor(), mq.TLO.Cursor():sub(1,1), 'Tribute')
-                loot.logger.Info(string.format("Setting \ay%s\ax to \ay%s\ax", mq.TLO.Cursor(), 'Tribute'))
-            end
         elseif args[1] == 'loot' then
             loot.lootMobs()
         elseif args[1] == 'tsbank' then

--- a/init.lua
+++ b/init.lua
@@ -894,8 +894,10 @@ end
 
 local function processArgs(args)
     if #args == 1 then
-        if args[1] == 'sell' then
+        if args[1] == 'sellstuff' then
             loot.sellStuff()
+        elseif args[1] == 'tributestuff' then
+            loot.tributeStuff()
         elseif args[1] == 'once' then
             loot.lootMobs()
         elseif args[1] == 'standalone' then

--- a/loot_hist.lua
+++ b/loot_hist.lua
@@ -1,0 +1,154 @@
+local mq = require('mq')
+local imgui = require('ImGui')
+
+
+local guiLoot = {
+	SHOW = false,
+	openGUI = true,
+	shouldDrawGUI = false,
+	imported = false,
+
+	---@type ConsoleWidget
+	console = nil,
+	localEcho = false,
+	resetPosition = false,
+}
+
+function MakeColorGradient(freq1, freq2, freq3, phase1, phase2, phase3, center, width, length)
+	local text = ''
+
+	for i = 1, length do
+		local color = IM_COL32(
+			math.floor(math.sin(freq1 * i + phase1) * width + center),
+			math.floor(math.sin(freq2 * i + phase2) * width + center),
+			math.floor(math.sin(freq3 * i + phase3) * width + center)
+		)
+
+		text = text .. string.format("\a#%06xx", bit32.band(color, 0xffffff))
+
+		if i % 50 == 0 then
+			guiLoot.console:AppendText(text)
+			text = ''
+		end
+	end
+
+	guiLoot.console:AppendText(text)
+end
+
+function guiLoot.GUI()
+	if guiLoot.console == nil then
+		guiLoot.console = imgui.ConsoleWidget.new("##Console")
+	end
+	if not guiLoot.shouldDrawGUI then return end
+	local flags = ImGuiWindowFlags.MenuBar
+	imgui.SetNextWindowSize(ImVec2(640, 240), guiLoot.resetPosition and ImGuiCond.Always or ImGuiCond.Once)
+	imgui.PushStyleVar(ImGuiStyleVar.WindowPadding, ImVec2(1, 0));
+
+	guiLoot.openGUI, guiLoot.shouldDrawGUI = ImGui.Begin('Looted Items##'..mq.TLO.Me.DisplayName(), guiLoot.openGUI, flags)
+	imgui.PopStyleVar()
+	if not guiLoot.shouldDrawGUI then
+		imgui.End()
+		return
+	end
+
+	-- Main menu bar
+	if imgui.BeginMenuBar() then
+		if imgui.BeginMenu('Options') then
+			_, guiLoot.console.autoScroll = imgui.MenuItem('Auto-scroll', nil, guiLoot.console.autoScroll)
+
+			imgui.Separator()
+
+			if imgui.MenuItem('Reset Position') then
+				guiLoot.resetPosition = true
+			end
+
+			imgui.Separator()
+
+			if imgui.MenuItem('Clear Console') then
+				guiLoot.console:Clear()
+			end
+
+			imgui.Separator()
+
+			if imgui.MenuItem('Close Console') then
+				guiLoot.SHOW = false
+			end
+
+			imgui.EndMenu()
+		end
+		imgui.EndMenuBar()
+	end
+	-- End of menu bar
+
+	local footerHeight = imgui.GetStyle().ItemSpacing.y + imgui.GetFrameHeightWithSpacing()
+
+	if imgui.BeginPopupContextWindow() then
+		if imgui.Selectable('Clear') then
+			guiLoot.console:Clear()
+		end
+		imgui.EndPopup()
+	end
+
+	-- Reduce spacing so everything fits snugly together
+	imgui.PushStyleVar(ImGuiStyleVar.ItemSpacing, ImVec2(0, 0))
+	local contentSizeX, contentSizeY = imgui.GetContentRegionAvail()
+	contentSizeY = contentSizeY - footerHeight
+
+	guiLoot.console:Render(ImVec2(contentSizeX, contentSizeY))
+	imgui.PopStyleVar()
+
+	ImGui.End()
+end
+
+function StringTrim(s)
+	return s:gsub("^%s*(.-)%s*$", "%1")
+end
+
+function guiLoot.EventLoot(line,who,what)
+	print(who.." : "..what)
+	if guiLoot.console ~= nil then
+		local item = mq.TLO.FindItem(what).ItemLink('CLICKABLE')() or what
+		if mq.TLO.Plugin('mq2linkdb').IsLoaded() then 
+			item = mq.TLO.FindItem(what).ItemLink('CLICKABLE')() or mq.TLO.LinkDB(string.format("=%s",what))()
+		end
+		local text = string.format('\at%s \axLooted %s',who, item)
+		guiLoot.console:AppendText(text)
+	end
+end
+
+local function bind(...)
+	local args = {...}
+	if args[1] == 'show' then
+		guiLoot.shouldDrawGUI = not guiLoot.shouldDrawGUI
+	elseif args[1] == 'stop' then
+		guiLoot.SHOW = false
+	end
+end
+
+local args = {...}
+if args[1] == 'start' then
+	mq.bind('/looted', bind)
+	guiLoot.SHOW = true
+	local echo = "\ay[Looted]\ax Commands:\n"
+	echo = echo .. "\ay[Looted]\ax /looted show \t\atToggles the Gui\n\ax"
+	echo = echo .. "\ay[Looted]\ax /looted stop \t\atExits script\n\ax"
+	print(echo)
+end
+
+if not mq.TLO.Plugin('mq2linkdb').IsLoaded() then
+	mq.cmd('/plugin linkdb load')
+end
+
+if guiLoot.imported then
+	guiLoot.SHOW = true
+end
+mq.imgui.init('lootItemsGUI', guiLoot.GUI)
+mq.event('echo_Loot', '--#1# have looted a #2#.#*#', guiLoot.EventLoot)
+mq.event('echo_Loot2', '--#1# has looted a #2#.#*#', guiLoot.EventLoot)
+
+while guiLoot.SHOW do
+	mq.delay(100)
+	mq.doevents()
+end
+
+return guiLoot

--- a/loot_hist.lua
+++ b/loot_hist.lua
@@ -71,6 +71,7 @@ function guiLoot.GUI()
 			imgui.Separator()
 
 			if imgui.MenuItem('Close Console') then
+				guiLoot.shouldDrawGUI = false
 				guiLoot.SHOW = false
 			end
 

--- a/loot_hist.lua
+++ b/loot_hist.lua
@@ -1,13 +1,37 @@
-local mq = require('mq')
-local imgui = require('ImGui')
+--[[
+	Title: Looted
+	Author: Grimmier
+	Description:
 
+	Simple output console for looted items and links. 
+	can be run standalone or imported into other scripts. 
 
+	Standalone Mode
+	/lua run looted start 		-- start in standalone mode
+	/lua run looted hidenames 	-- will start with player names hidden and class names used instead.
+
+	Standalone Commands
+	/looted show 				-- toggles show hide on window.
+	/looted stop 				-- exit sctipt.
+	/looted hidenames 			-- Toggles showing names or class names. default is names.
+
+	Or you can Import into another Lua.
+
+	Import Mode
+
+	1. place in your scripts folder name it looted.Lua.
+	2. local guiLoot = require('looted')
+	3. guiLoot.imported = true
+	4. guiLoot.openGUI = true|false to show or hide window.
+	5. guiLoot.hideNames = true|false toggle showing character names default is true.
+
+]]
 local mq = require('mq')
 local imgui = require('ImGui')
 
 local guiLoot = {
 	SHOW = false,
-	openGUI = true,
+	openGUI = false,
 	shouldDrawGUI = false,
 	imported = false,
 	hideNames = false,
@@ -16,7 +40,10 @@ local guiLoot = {
 	console = nil,
 	localEcho = false,
 	resetPosition = false,
+
+	winFlags = bit32.bor(ImGuiWindowFlags.MenuBar)
 }
+
 
 function MakeColorGradient(freq1, freq2, freq3, phase1, phase2, phase3, center, width, length)
 	local text = ''
@@ -41,15 +68,18 @@ end
 
 function guiLoot.GUI()
 	if not guiLoot.openGUI then return end
-	local flags = ImGuiWindowFlags.MenuBar
-	ImGui.SetNextWindowSize(260, 300, ImGuiCond.FirstUseEver)
-	imgui.PushStyleVar(ImGuiStyleVar.WindowPadding, ImVec2(1, 0));
 
-	guiLoot.openGUI, guiLoot.shouldDrawGUI = ImGui.Begin('Looted Items##'..mq.TLO.Me.DisplayName(), guiLoot.openGUI, flags)
-	if not guiLoot.shouldDrawGUI then
+	local windowName = 'Looted Items##'..mq.TLO.Me.DisplayName()
+
+	ImGui.SetNextWindowSize(260, 300, ImGuiCond.FirstUseEver)
+	--imgui.PushStyleVar(ImGuiStyleVar.WindowPadding, ImVec2(1, 0));
+
+	if guiLoot.imported then windowName = 'Looted Items *##Imported_'..mq.TLO.Me.DisplayName() end
+	guiLoot.openGUI, guiLoot.shouldDrawGUI = ImGui.Begin(windowName, guiLoot.openGUI, guiLoot.winFlags)
+	if not guiLoot.openGUI then
 		imgui.End()
-		imgui.PopStyleVar()
-		guiLoot.openGUI = false
+		--imgui.PopStyleVar()
+		guiLoot.shouldDrawGUI = false
 		return
 	end
 
@@ -73,9 +103,34 @@ function guiLoot.GUI()
 			imgui.Separator()
 
 			if imgui.MenuItem('Close Console') then
-				guiLoot.shouldDrawGUI = false
-				guiLoot.SHOW = false
+				guiLoot.openGUI = false
 			end
+
+			imgui.Separator()
+			local activated = false
+			activated, guiLoot.hideNames = imgui.MenuItem('Hide Names', activated, guiLoot.hideNames)
+			if activated then
+				if guiLoot.hideNames then
+					print("\ay[Looted]\ax Hiding Names\ax")
+				else
+					print("\ay[Looted]\ax Showing Names\ax")
+				end
+			end
+
+			imgui.Separator()
+
+			if imgui.MenuItem('Exit') then
+				if not guiLoot.imported then
+					guiLoot.SHOW = false
+				else
+					guiLoot.openGUI = false
+					print("\ay[Looted]\ax Can Not Exit in Imported Mode.\ar Closing Window instead.\ax")
+				end
+			end
+
+			imgui.Separator()
+
+			imgui.Spacing()
 
 			imgui.EndMenu()
 		end
@@ -97,8 +152,8 @@ function guiLoot.GUI()
 	local contentSizeX, contentSizeY = imgui.GetContentRegionAvail()
 	contentSizeY = contentSizeY - footerHeight
 
-	guiLoot.console:Render(ImVec2(contentSizeX, contentSizeY))
-	imgui.PopStyleVar(2)
+	guiLoot.console:Render(ImVec2(contentSizeX,0))
+	imgui.PopStyleVar(1)
 
 	ImGui.End()
 end
@@ -130,6 +185,11 @@ local function bind(...)
 		guiLoot.SHOW = false
 	elseif args[1] == 'hidenames' then
 		guiLoot.hideNames = not guiLoot.hideNames
+		if guiLoot.hideNames then
+			print("\ay[Looted]\ax Hiding Names\ax")
+		else
+			print("\ay[Looted]\ax Showing Names\ax")
+		end
 	end
 end
 
@@ -150,7 +210,7 @@ local function checkArgs(args)
 	local echo = "\ay[Looted]\ax Commands:\n"
 	echo = echo .. "\ay[Looted]\ax /looted show \t\t\atToggles the Gui.\n\ax"
 	echo = echo .. "\ay[Looted]\ax /looted stop \t\t\atExits script.\n\ax"
-	echo = echo .. "\ay[Looted]\ax /looted hidenames \t\atHides names and shows Class instead.\n\ax"
+	echo = echo .. "\ay[Looted]\ax /looted hidenames\t\atHides names and shows Class instead.\n\ax"
 	print(echo)
 end
 
@@ -163,18 +223,21 @@ local function init()
 	-- if imported set show to true.
 	if guiLoot.imported then
 		guiLoot.SHOW = true
+		mq.imgui.init('importedLootItemsGUI', guiLoot.GUI)
+	else
+		mq.imgui.init('lootItemsGUI', guiLoot.GUI)
 	end
 
-	-- initialize the gui
-	mq.imgui.init('lootItemsGUI', guiLoot.GUI)
-
 	-- setup events
-	mq.event('echo_Loot', '--#1# have looted a #2#.#*#', guiLoot.EventLoot)
-	mq.event('echo_Loot2', '--#1# has looted a #2#.#*#', guiLoot.EventLoot)
+	mq.event('echo_Loot', '--#1# ha#*# looted a #2#.#*#', guiLoot.EventLoot)
 
 	-- initialize the console
 	if guiLoot.console == nil then
-		guiLoot.console = imgui.ConsoleWidget.new("Loot##Console")
+		if guiLoot.imported then
+			guiLoot.console = imgui.ConsoleWidget.new("Loot_imported##Imported_Console")
+		else
+			guiLoot.console = imgui.ConsoleWidget.new("Loot##Console")
+		end
 	end
 end
 

--- a/loot_hist.lua
+++ b/loot_hist.lua
@@ -45,9 +45,9 @@ function guiLoot.GUI()
 	imgui.PushStyleVar(ImGuiStyleVar.WindowPadding, ImVec2(1, 0));
 
 	guiLoot.openGUI, guiLoot.shouldDrawGUI = ImGui.Begin('Looted Items##'..mq.TLO.Me.DisplayName(), guiLoot.openGUI, flags)
-	imgui.PopStyleVar()
 	if not guiLoot.shouldDrawGUI then
 		imgui.End()
+		imgui.PopStyleVar()
 		return
 	end
 
@@ -96,7 +96,7 @@ function guiLoot.GUI()
 	contentSizeY = contentSizeY - footerHeight
 
 	guiLoot.console:Render(ImVec2(contentSizeX, contentSizeY))
-	imgui.PopStyleVar()
+	imgui.PopStyleVar(2)
 
 	ImGui.End()
 end
@@ -106,7 +106,6 @@ function StringTrim(s)
 end
 
 function guiLoot.EventLoot(line,who,what)
-	print(who.." : "..what)
 	if guiLoot.console ~= nil then
 		local item = mq.TLO.FindItem(what).ItemLink('CLICKABLE')() or what
 		if mq.TLO.Plugin('mq2linkdb').IsLoaded() then 


### PR DESCRIPTION
* Added Settings:
* * TributeKeep keep items marked as tribute?
* * MinTributeValue min value to mark as tribute.
* * AlwaysEval re-evaluate items not marked as quest keep or destroy
* * BankTradeskills whether to auto set and bank tradeskill items.

* /lootutils
* * Now checks for item on cursor and will set value in the ini file.
* * /lootutils tribute will mark if on cursor or tribute items
* * /lootutils sell will mark if on cursor or sell

* AddNewSales wasn't working, added mq.doevents to loop to fix this.
* Added check if corpse is your own /lootall and bypass any checks.