### PR TITLE
New Settings, Tooltips, Directed Mode tweaks...

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -11,34 +11,34 @@ if not success then
     printf('\arERROR: Write.lua could not be loaded\n%s\ax', Logger)
     return
 end
-local eqServer                       = string.gsub(mq.TLO.EverQuest.Server(), ' ', '_')
-local version                        = 6
-local MyName                         = mq.TLO.Me.DisplayName()
-local Mode                           = 'once'
-local Files                          = require('mq.Utils')
-local SettingsFile                   = string.format('%s/LootNScoot/%s/%s.lua', mq.configDir, eqServer, MyName)
-local imported                       = true
-local lootDBUpdateFile               = string.format('%s/LootNScoot/%s/DB_Updated.lua', mq.configDir, eqServer)
-local zoneID                         = 0
-local lootedCorpses                  = {}
-local tmpRules, tmpClasses, tmpLinks = {}, {}, {}
-local ProcessItemsState              = nil
-local reportPrefix                   = '/%s \a-t[\at%s\a-t][\ax\ayLootUtils\ax\a-t]\ax '
-Logger.prefix                        = "[\atLootnScoot\ax] "
-local newItem                        = nil
-local debugPrint                     = false
-local iconAnimation                  = mq.FindTextureAnimation('A_DragItem')
+local eqServer                          = string.gsub(mq.TLO.EverQuest.Server(), ' ', '_')
+local version                           = 6
+local MyName                            = mq.TLO.Me.DisplayName()
+local Mode                              = 'once'
+local Files                             = require('mq.Utils')
+local SettingsFile                      = string.format('%s/LootNScoot/%s/%s.lua', mq.configDir, eqServer, MyName)
+local imported                          = true
+local lootDBUpdateFile                  = string.format('%s/LootNScoot/%s/DB_Updated.lua', mq.configDir, eqServer)
+local zoneID                            = 0
+local lootedCorpses                     = {}
+local tmpRules, tmpClasses, tmpLinks    = {}, {}, {}
+local ProcessItemsState                 = nil
+local reportPrefix                      = '/%s \a-t[\at%s\a-t][\ax\ayLootUtils\ax\a-t]\ax '
+Logger.prefix                           = "[\atLootnScoot\ax] "
+local newItem                           = nil
+local debugPrint                        = false
+local iconAnimation                     = mq.FindTextureAnimation('A_DragItem')
 -- Internal settings
-local cantLootList                   = {}
-local cantLootID                     = 0
-local itemNoValue                    = nil
-local noDropItems, loreItems         = {}, {}
-local allItems                       = {}
-local foragingLoot                   = false
+local cantLootList                      = {}
+local cantLootID                        = 0
+local itemNoValue                       = nil
+local noDropItems, loreItems            = {}, {}
+local allItems                          = {}
+local foragingLoot                      = false
 -- Constants
-local spawnSearch                    = '%s radius %d zradius 50'
-local shouldLootActions              = { Ask = false, CanUse = false, Keep = true, Bank = true, Sell = true, Destroy = false, Ignore = false, Tribute = false, }
-local validActions                   = {
+local spawnSearch                       = '%s radius %d zradius 50'
+local shouldLootActions                 = { Ask = false, CanUse = false, Keep = true, Bank = true, Sell = true, Destroy = false, Ignore = false, Tribute = false, }
+local validActions                      = {
     ask = "Ask",
     canuse = "CanUse",
     keep = 'Keep',
@@ -49,30 +49,30 @@ local validActions                   = {
     quest = 'Quest',
     tribute = 'Tribute',
 }
-local saveOptionTypes                = { string = 1, number = 1, boolean = 1, }
-local NEVER_SELL                     = { ['Diamond Coin'] = true, ['Celestial Crest'] = true, ['Gold Coin'] = true, ['Taelosian Symbols'] = true, ['Planar Symbols'] = true, }
-local showNewItem                    = false
-local lookupDate                     = ''
-local Actors                         = require('actors')
+local saveOptionTypes                   = { string = 1, number = 1, boolean = 1, }
+local NEVER_SELL                        = { ['Diamond Coin'] = true, ['Celestial Crest'] = true, ['Gold Coin'] = true, ['Taelosian Symbols'] = true, ['Planar Symbols'] = true, }
+local showNewItem                       = false
+local lookupDate                        = ''
+local Actors                            = require('actors')
 
 -- paths
-local resourceDir                    = mq.TLO.MacroQuest.Path('resources')() .. "/"
-local RulesDB                        = string.format('%s/LootNScoot/%s/AdvLootRules.db', resourceDir, eqServer)
-local lootDB                         = string.format('%s/LootNScoot/%s/Items.db', resourceDir, eqServer)
-local HistoryDB                      = string.format('%s/LootNScoot/%s/LootHistory.db', resourceDir, eqServer)
+local resourceDir                       = mq.TLO.MacroQuest.Path('resources')() .. "/"
+local RulesDB                           = string.format('%s/LootNScoot/%s/AdvLootRules.db', resourceDir, eqServer)
+local lootDB                            = string.format('%s/LootNScoot/%s/Items.db', resourceDir, eqServer)
+local HistoryDB                         = string.format('%s/LootNScoot/%s/LootHistory.db', resourceDir, eqServer)
 
 -- gui
-local fontScale                      = 1
-local iconSize                       = 16
-local tempValues                     = {}
-local animMini                       = mq.FindTextureAnimation("A_DragItem")
-local EQ_ICON_OFFSET                 = 500
-local showSettings                   = false
-
-
+local fontScale                         = 1
+local iconSize                          = 16
+local tempValues                        = {}
+local animMini                          = mq.FindTextureAnimation("A_DragItem")
+local EQ_ICON_OFFSET                    = 500
+local showSettings                      = false
+local enteredSafeZone                   = false
 -- tables
 local settingsEnum                      = {
     checkcorpseonce = 'CheckCorpseOnce',
+    ignoremynearcorpses = 'IgnoreMyNearCorpses',
     autoshownewitem = 'AutoShowNewItem',
     keepspells = 'KeepSpells',
     canwear = 'CanWear',
@@ -162,57 +162,110 @@ local LNS       = {}
 LNS.CurrentPage = LNS.CurrentPage or 1
 
 LNS.Settings    = {
-    Version          = '"' .. tostring(version) .. '"',
-    GlobalLootOn     = true,   -- Enable Global Loot Items. not implimented yet
-    CombatLooting    = false,  -- Enables looting during combat. Not recommended on the MT
-    CorpseRadius     = 100,    -- Radius to activly loot corpses
-    MobsTooClose     = 40,     -- Don't loot if mobs are in this range.
-    SaveBagSlots     = 3,      -- Number of bag slots you would like to keep empty at all times. Stop looting if we hit this number
-    TributeKeep      = false,  -- Keep items flagged Tribute
-    MinTributeValue  = 100,    -- Minimun Tribute points to keep item if TributeKeep is enabled.
-    MinSellPrice     = -1,     -- Minimum Sell price to keep item. -1                                    = any
-    StackPlatValue   = 0,      -- Minimum sell value for full stack
-    StackableOnly    = false,  -- Only loot stackable items
-    AlwaysEval       = false,  -- Re-Evaluate all *Non Quest* items. useful to update loot.ini after changing min sell values.
-    BankTradeskills  = false,  -- Toggle flagging Tradeskill items as Bank or not.
-    DoLoot           = true,   -- Enable auto looting in standalone mode
-    LootForage       = true,   -- Enable Looting of Foraged Items
-    LootNoDrop       = false,  -- Enable Looting of NoDrop items.
-    LootNoDropNew    = false,  -- Enable looting of new NoDrop items.
-    LootQuest        = true,   -- Enable Looting of Items Marked 'Quest', requires LootNoDrop on to loot NoDrop quest items
-    DoDestroy        = false,  -- Enable Destroy functionality. Otherwise 'Destroy' acts as 'Ignore'
-    AlwaysDestroy    = false,  -- Always Destroy items to clean corpese Will Destroy Non-Quest items marked 'Ignore' items REQUIRES DoDestroy set to true
-    QuestKeep        = 10,     -- Default number to keep if item not set using Quest|# format.
-    LootChannel      = "dgt",  -- Channel we report loot to.
-    GroupChannel     = "dgze", -- Channel we use for Group Commands Default(dgze)
-    ReportLoot       = true,   -- Report loot items to group or not.
-    SpamLootInfo     = false,  -- Echo Spam for Looting
-    LootForageSpam   = false,  -- Echo spam for Foraged Items
-    AddNewSales      = true,   -- Adds 'Sell' Flag to items automatically if you sell them while the script is running.
-    AddNewTributes   = true,   -- Adds 'Tribute' Flag to items automatically if you Tribute them while the script is running.
-    GMLSelect        = true,   -- not implimented yet
-    LootLagDelay     = 0,      -- not implimented yet
-    HideNames        = false,  -- Hides names and uses class shortname in looted window
-    RecordData       = true,   -- Enables recording data to report later.
-    AutoTag          = false,  -- Automatically tag items to sell if they meet the MinSellPrice
-    AutoRestock      = true,   -- Automatically restock items from the BuyItems list when selling
-    LootMyCorpse     = false,  -- Loot your own corpse if its nearby (Does not check for REZ)
-    LootAugments     = false,  -- Loot Augments
-    CheckCorpseOnce  = true,   -- Check Corpse once and move on. Ignore the next time it is in range if enabled
-    AutoShowNewItem  = false,  -- Automatically show new items in the looted window
-    KeepSpells       = true,   -- Keep spells
-    CanWear          = false,  -- Only loot items you can wear
-    ShowInfoMessages = true,
-    ShowConsole      = false,
-    ShowReport       = false,
-    IgnoreBagSlot    = 0,     -- Ignore this Bag Slot when buying, selling, tributing and destroying of items.
-    AlwaysGlobal     = false, -- Always assign new rules to global as well as normal rules.
+    Version             = '"' .. tostring(version) .. '"',
+    GlobalLootOn        = true,   -- Enable Global Loot Items. not implimented yet
+    CombatLooting       = false,  -- Enables looting during combat. Not recommended on the MT
+    CorpseRadius        = 100,    -- Radius to activly loot corpses
+    MobsTooClose        = 40,     -- Don't loot if mobs are in this range.
+    SaveBagSlots        = 3,      -- Number of bag slots you would like to keep empty at all times. Stop looting if we hit this number
+    TributeKeep         = false,  -- Keep items flagged Tribute
+    MinTributeValue     = 100,    -- Minimun Tribute points to keep item if TributeKeep is enabled.
+    MinSellPrice        = -1,     -- Minimum Sell price to keep item. -1                                    = any
+    StackPlatValue      = 0,      -- Minimum sell value for full stack
+    StackableOnly       = false,  -- Only loot stackable items
+    AlwaysEval          = false,  -- Re-Evaluate all *Non Quest* items. useful to update loot.ini after changing min sell values.
+    BankTradeskills     = false,  -- Toggle flagging Tradeskill items as Bank or not.
+    DoLoot              = true,   -- Enable auto looting in standalone mode
+    LootForage          = true,   -- Enable Looting of Foraged Items
+    LootNoDrop          = false,  -- Enable Looting of NoDrop items.
+    LootNoDropNew       = false,  -- Enable looting of new NoDrop items.
+    LootQuest           = true,   -- Enable Looting of Items Marked 'Quest', requires LootNoDrop on to loot NoDrop quest items
+    DoDestroy           = false,  -- Enable Destroy functionality. Otherwise 'Destroy' acts as 'Ignore'
+    AlwaysDestroy       = false,  -- Always Destroy items to clean corpese Will Destroy Non-Quest items marked 'Ignore' items REQUIRES DoDestroy set to true
+    QuestKeep           = 10,     -- Default number to keep if item not set using Quest|# format.
+    LootChannel         = "dgt",  -- Channel we report loot to.
+    GroupChannel        = "dgze", -- Channel we use for Group Commands Default(dgze)
+    ReportLoot          = true,   -- Report loot items to group or not.
+    SpamLootInfo        = false,  -- Echo Spam for Looting
+    LootForageSpam      = false,  -- Echo spam for Foraged Items
+    AddNewSales         = true,   -- Adds 'Sell' Flag to items automatically if you sell them while the script is running.
+    AddNewTributes      = true,   -- Adds 'Tribute' Flag to items automatically if you Tribute them while the script is running.
+    GMLSelect           = true,   -- not implimented yet
+    LootLagDelay        = 0,      -- not implimented yet
+    HideNames           = false,  -- Hides names and uses class shortname in looted window
+    RecordData          = true,   -- Enables recording data to report later.
+    AutoTag             = false,  -- Automatically tag items to sell if they meet the MinSellPrice
+    AutoRestock         = true,   -- Automatically restock items from the BuyItems list when selling
+    LootMyCorpse        = false,  -- Loot your own corpse if its nearby (Does not check for REZ)
+    LootAugments        = false,  -- Loot Augments
+    CheckCorpseOnce     = true,   -- Check Corpse once and move on. Ignore the next time it is in range if enabled
+    AutoShowNewItem     = false,  -- Automatically show new items in the looted window
+    KeepSpells          = true,   -- Keep spells
+    CanWear             = false,  -- Only loot items you can wear
+    ShowInfoMessages    = true,
+    ShowConsole         = false,
+    ShowReport          = false,
+    IgnoreBagSlot       = 0,     -- Ignore this Bag Slot when buying, selling, tributing and destroying of items.
+    AlwaysGlobal        = false, -- Always assign new rules to global as well as normal rules.
+    IgnoreMyNearCorpses = false, -- Ignore my own corpses when looting nearby corpses, some servers you spawn after death with all your gear so this setting is handy.
     -- ProcessingEval   = true, -- Re evaluate when processing items for sell\tribute? this will re check our settings and not sell or tribute items outside the new parameters
-    BuyItemsTable    = {
+    BuyItemsTable       = {
         ['Iron Ration'] = 20,
         ['Water Flask'] = 20,
     },
 }
+
+LNS.Tooltips    = {
+    GlobalLootOn        = "Enable Global Loot Items. not implimented yet",
+    CombatLooting       = "Enables looting during combat. Not recommended on the MT",
+    CorpseRadius        = "Radius to activly loot corpses",
+    MobsTooClose        = "Don't loot if mobs are in this range.",
+    SaveBagSlots        = "Number of bag slots you would like to keep empty at all times. Stop looting if we hit this number",
+    TributeKeep         = "Keep items flagged Tribute",
+    MinTributeValue     = "Minimun Tribute points to keep item if TributeKeep is enabled.",
+    MinSellPrice        = "Minimum Sell price to keep item. -1 = any",
+    StackPlatValue      = "Minimum sell value for full stack",
+    StackableOnly       = "Only loot stackable items",
+    AlwaysEval          = "Re-Evaluate all *Non Quest* items. useful to update loot.ini after changing min sell values.",
+    BankTradeskills     = "Toggle flagging Tradeskill items as Bank or not.",
+    DoLoot              = "Enable auto looting in standalone mode",
+    LootForage          = "Enable Looting of Foraged Items",
+    LootNoDrop          = "Enable Looting of NoDrop items.",
+    LootNoDropNew       = "Enable looting of new NoDrop items.",
+    LootQuest           = "Enable Looting of Items Marked 'Quest', requires LootNoDrop on to loot NoDrop quest items",
+    DoDestroy           = "Enable Destroy functionality. Otherwise 'Destroy' acts as 'Ignore'",
+    AlwaysDestroy       = {
+        [1] = "Always Destroy items to clean corpese Will Destroy Non-Quest items marked 'Ignore' items",
+        [2] = "REQUIRES DoDestroy set to true",
+    },
+    QuestKeep           = "Default number to keep if item not set using Quest|# format.",
+    LootChannel         = "Channel we report loot to.",
+    GroupChannel        = "Channel we use for Group Commands Default(dgze)",
+    ReportLoot          = "Report loot items to group or not.",
+    SpamLootInfo        = "Echo Spam for Looting",
+    LootForageSpam      = "Echo spam for Foraged Items",
+    AddNewSales         = "Adds 'Sell' Flag to items automatically if you sell them while the script is running.",
+    AddNewTributes      = "Adds 'Tribute' Flag to items automatically if you Tribute them while the script is running.",
+    GMLSelect           = "not implimented yet",
+    LootLagDelay        = "not implimented yet",
+    HideNames           = "Hides names and uses class shortname in looted window",
+    RecordData          = "Enables recording data to report later.",
+    AutoTag             = "Automatically tag items to sell if they meet the MinSellPrice",
+    AutoRestock         = "Automatically restock items from the BuyItems list when selling",
+    LootMyCorpse        = "Loot your own corpse if its nearby (Does not check for REZ)",
+    LootAugments        = "Loot Augments",
+    CheckCorpseOnce     = "Check Corpse once and move on. Ignore the next time it is in range if enabled",
+    AutoShowNewItem     = "Automatically show new items in the looted window",
+    KeepSpells          = "Keep spells",
+    CanWear             = "Only loot items you can wear",
+    ShowInfoMessages    = "Show or Hide [INFO] Messages in the loot console",
+    ShowConsole         = "Show or Hide the Loot Console window",
+    ShowReport          = "Prints report to the Console also toggles the report table window open if its closed.",
+    IgnoreBagSlot       = "gnore this Bag Slot when buying, selling, tributing and destroying of items.",
+    AlwaysGlobal        = "lways assign new rules to global as well as normal rules.",
+    IgnoreMyNearCorpses = "gnore my own corpses when looting nearby corpses, some servers you spawn after death with all your gear so this setting is handy.",
+}
+
 local tmpCmd    = LNS.GroupChannel or 'dgae'
 
 LNS.MyClass     = mq.TLO.Me.Class.ShortName():lower()
@@ -266,17 +319,21 @@ LNS.TempSettings.SortedSettingsKeys = {}
 LNS.TempSettings.SortedToggleKeys   = {}
 LNS.TempSettings.UpdateSettings     = false
 LNS.TempSettings.SendSettings       = false
+LNS.TempSettings.LastZone           = nil
+LNS.SafeZones                       = {}
 LNS.PauseLooting                    = false
+LNS.Zone                            = mq.TLO.Zone.ShortName()
 
-local tableList                     = {
+
+local tableList            = {
     "Global_Items", "Normal_Items", LNS.PersonalTableName,
 }
-local tableListRules                = {
+local tableListRules       = {
     "Global_Rules", "Normal_Rules", LNS.PersonalTableName,
 }
 
 -- FORWARD DECLARATIONS
-LNS.AllItemColumnListIndex          = {
+LNS.AllItemColumnListIndex = {
     [1]  = 'name',
     [2]  = 'sell_value',
     [3]  = 'tribute_value',
@@ -460,11 +517,13 @@ function LNS.SortKeys(input_table)
     return keys
 end
 
-function LNS.writeSettings()
+function LNS.writeSettings(caller)
     mq.cmdf("/squelch /mapfilter CastRadius %d", LNS.Settings.CorpseRadius)
     LNS.Settings.BuyItemsTable = LNS.BuyItemsTable
     mq.pickle(SettingsFile, LNS.Settings)
-    Logger.Debug(LNS.guiLoot.console, "Loot::writeSettings()")
+    LNS.Boxes[MyName] = LNS.Settings
+
+    Logger.Debug(LNS.guiLoot.console, { Lookup = "Loot::writeSettings()", CalledFrom = caller, })
 end
 
 ---@param firstRun boolean|nil if passed true then we will load the DB's again
@@ -484,6 +543,7 @@ function LNS.loadSettings(firstRun)
         LNS.PersonalItemsLink    = {}
         LNS.ItemNames            = {}
         LNS.ALLITEMS             = {}
+        LNS.SafeZones            = {}
     end
     local needDBUpdate = false
     local needSave     = false
@@ -760,7 +820,7 @@ end
 function LNS.commandHandler(...)
     local args = { ..., }
     local item = mq.TLO.Cursor -- Capture the cursor item early for reuse
-
+    local needSave = false
     if args[1] == 'set' then
         local setting    = args[2]:lower()
         local settingVal = args[3]
@@ -778,11 +838,11 @@ function LNS.commandHandler(...)
                 LNS.Settings[settingName] = settingVal
             end
             Logger.Info(LNS.guiLoot.console, "Setting \ay%s\ax to \ag%s\ax", settingName, settingVal)
-            LNS.writeSettings()
+            needSave = true
         else
             Logger.Warn(LNS.guiLoot.console, "Invalid setting name: %s", setting)
         end
-        LNS.writeSettings()
+        if needSave then LNS.writeSettings("CommandHandler:set") end
         LNS.sendMySettings()
         return
     end
@@ -817,11 +877,11 @@ function LNS.commandHandler(...)
             LNS.processItems('Buy')
         elseif command == 'debug' then
             debugPrint = not debugPrint
-            Logger.Info(LNS.guiLoot.console, "\ayDebugging\ax is now %s", debugPrint and "\agon" or "\aroff")
+            Logger.Warn(LNS.guiLoot.console, "\ayDebugging\ax is now %s", debugPrint and "\agon" or "\aroff")
         elseif command == 'reload' then
             local needSave = LNS.loadSettings()
             if needSave then
-                LNS.writeSettings()
+                LNS.writeSettings("CommandHandler:reload")
             end
             if LNS.guiLoot then
                 LNS.guiLoot.GetSettings(
@@ -960,7 +1020,10 @@ function LNS.commandHandler(...)
             Logger.Info(LNS.guiLoot.console, "Setting \ay%s\ax to \agBuy Item\ax", args[2])
         end
     end
-    LNS.writeSettings()
+    if LNS.TempSettings.NeedSave then
+        LNS.writeSettings("CommandHandler:args")
+        LNS.TempSettings.NeedSave = false
+    end
 end
 
 function LNS.setupBinds()
@@ -1096,7 +1159,7 @@ function LNS.enterNewItemRuleInfo(data_table)
     if LNS.Settings.AlwaysGlobal then
         modMessage.section = "GlobalItems"
         LNS.lootActor:send({ mailbox = 'lootnscoot', script = 'lootnscoot', }, modMessage)
-        if Mode == 'directed' then
+        if Mode == 'directed' and LNS.DirectorLNSPath ~= 'lootnscoot' then
             LNS.lootActor:send({ mailbox = 'lootnscoot', script = LNS.DirectorLNSPath, }, modMessage)
         end
     end
@@ -1166,6 +1229,71 @@ function LNS.LoadDateHistory(lookup_Date)
     db:close()
 end
 
+function LNS.AddSafeZone(zoneName)
+    if not zoneName or zoneName == "" then return end
+    local db = SQLite3.open(RulesDB)
+    db:exec("PRAGMA journal_mode=WAL;")
+    db:exec("BEGIN TRANSACTION")
+
+    local stmt = db:prepare("INSERT OR IGNORE INTO SafeZones (zone) VALUES (?)")
+    stmt:bind_values(zoneName)
+    local res, err = stmt:step()
+    if res ~= SQLite3.DONE then
+        printf("Error inserting safe zone: %s ", err)
+    end
+    stmt:finalize()
+
+    db:exec("COMMIT")
+    db:close()
+    LNS.SafeZones[zoneName] = true
+    LNS.lootActor:send({ mailbox = 'lootnscoot', script = 'lootnscoot', }, {
+        who = MyName,
+        action = 'addsafezone',
+        zone = zoneName,
+    })
+    if Mode == 'directed' and LNS.DirectorLNSPath ~= 'lootnscoot' then
+        LNS.lootActor:send({ mailbox = 'lootnscoot', script = LNS.DirectorLNSPath, }, {
+            who = MyName,
+            action = 'addsafezone',
+            zone = zoneName,
+        })
+    end
+    if LNS.SafeZones[LNS.Zone] then
+        Logger.Warn(LNS.guiLoot.console, "You are in a safe zone: \at%s\ax \ayLooting Disabled", LNS.Zone)
+    end
+end
+
+function LNS.RemoveSafeZone(zoneName)
+    if not zoneName or zoneName == "" then return end
+    local db = SQLite3.open(RulesDB)
+    db:exec("PRAGMA journal_mode=WAL;")
+    db:exec("BEGIN TRANSACTION")
+
+    local stmt = db:prepare("DELETE FROM SafeZones WHERE zone = ?")
+    stmt:bind_values(zoneName)
+    local res, err = stmt:step()
+    if res ~= SQLite3.DONE then
+        printf("Error deleting safe zone: %s ", err)
+    end
+    stmt:finalize()
+
+    db:exec("COMMIT")
+    db:close()
+    LNS.SafeZones[zoneName] = nil
+    LNS.lootActor:send({ mailbox = 'lootnscoot', script = 'lootnscoot', }, {
+        who = MyName,
+        action = 'removesafezone',
+        zone = zoneName,
+    })
+    if Mode == 'directed' and LNS.DirectorLNSPath ~= 'lootnscoot' then
+        LNS.lootActor:send({ mailbox = 'lootnscoot', script = LNS.DirectorLNSPath, }, {
+            who = MyName,
+            action = 'removesafezone',
+            zone = zoneName,
+        })
+    end
+end
+
 function LNS.LoadItemHistory(lookup_name)
     local db = SQLite3.open(HistoryDB)
     db:exec("PRAGMA journal_mode=WAL;")
@@ -1208,7 +1336,7 @@ function LNS.insertIntoHistory(itemName, corpseName, action, date, timestamp, li
     local currentTime = convertTimestamp(timestamp)
 
     -- Skip if a duplicate "Ignore" or "Left" action exists within the last minute
-    if action == "Ignore" or action == "Left" or action == "CanUse" then
+    if action == "Ignore" or action == "Left" then
         local checkStmt = db:prepare([[
 SELECT Date, TimeStamp FROM LootHistory
 WHERE Item = ? AND CorpseName = ? AND Action = ? AND Date = ?
@@ -1308,6 +1436,9 @@ function LNS.LoadRuleDB()
         item_rule_classes TEXT,
         item_link TEXT
     );
+    CREATE TABLE IF NOT EXISTS SafeZones (
+        zone TEXT PRIMARY KEY NOT NULL UNIQUE
+    );
     ]], charTableName))
 
     local function processRules(stmt, ruleTable, classTable, linkTable)
@@ -1331,6 +1462,16 @@ function LNS.LoadRuleDB()
         processRules(stmt, LNS[lbl .. "ItemsRules"], LNS[lbl .. "ItemsClasses"], LNS[lbl .. "ItemsLink"])
         stmt:finalize()
     end
+
+    LNS.SafeZones = {}
+    local sz_stmt = db:prepare("SELECT * FROM SafeZones")
+    for row in sz_stmt:nrows() do
+        local zone = row.zone
+        if zone then
+            LNS.SafeZones[zone] = true
+        end
+    end
+    sz_stmt:finalize()
 
     db:exec("COMMIT")
     db:close()
@@ -1819,7 +1960,7 @@ DELETE FROM %s WHERE item_id = ?;
     for itemID, data in pairs(item_table) do
         local itemName = LNS.ItemNames[itemID] or nil
         local itemLink = data.Link
-        Logger.Debug(LNS.guiLoot.console, "Query: %s, itemID %s itemName %s, setting %s", qry, itemID, itemName, item_table[itemID].Rule)
+        Logger.Debug(LNS.guiLoot.console, "\nQuery: %s\ayValues\ax: itemID (\at%s\ax) itemName (\ay%s\ax), setting (\at%s)", qry, itemID, itemName, item_table[itemID].Rule)
 
         if itemName then
             if not delete_items then
@@ -1855,7 +1996,7 @@ DELETE FROM %s WHERE item_id = ?;
             bulkLink = LNS[localName .. 'Link'],
         }
         LNS.lootActor:send({ mailbox = 'lootnscoot', script = 'lootnscoot', }, message)
-        if Mode == 'directed' then
+        if Mode == 'directed' and LNS.DirectorLNSPath ~= 'lootnscoot' then
             LNS.lootActor:send({ mailbox = 'lootnscoot', script = LNS.DirectorLNSPath, }, message)
         end
     end
@@ -2245,7 +2386,7 @@ function LNS.modifyItemRule(itemID, action, tableName, classes, link)
             classes = classes,
         }
         LNS.lootActor:send({ mailbox = 'lootnscoot', script = 'lootnscoot', }, message)
-        if Mode == 'directed' then
+        if Mode == 'directed' and LNS.DirectorLNSPath ~= 'lootnscoot' then
             LNS.lootActor:send({ mailbox = 'lootnscoot', script = LNS.DirectorLNSPath, }, message)
         end
     end
@@ -3064,7 +3205,15 @@ function LNS.finishedLooting()
     if Mode == 'directed' then
         -- Logger.Info(LNS.guiLoot.console, "\ayInforming \ax\aw[\at%s\ax\aw]\ax that I am \agDone Looting.", LNS.DirectorScript)
         LNS.lootActor:send({ mailbox = 'loot_module', script = LNS.DirectorScript, },
-            { Subject = 'done_looting', Who = MyName, CombatLooting = LNS.Settings.CombatLooting, })
+            {
+                Subject = 'done_looting',
+                Who = MyName,
+                CombatLooting = LNS.Settings.CombatLooting,
+                CorpseRadius = LNS.Settings.CorpseRadius,
+                LootMyCorpse = LNS.Settings.LootMyCorpse,
+                IgnoreNearby = LNS.Settings.IgnoreMyNearCorpses,
+
+            })
     end
     LNS.LootNow = false
 end
@@ -3073,7 +3222,13 @@ function LNS.informProcessing()
     if Mode == 'directed' then
         Logger.Info(LNS.guiLoot.console, "\ayInforming \ax\aw[\at%s\ax\aw]\ax that I am \agProcessing.", LNS.DirectorScript)
         LNS.lootActor:send({ mailbox = 'loot_module', script = LNS.DirectorScript, },
-            { Subject = "processing", Who = MyName, CombatLooting = LNS.Settings.CombatLooting, })
+            {
+                Subject = "processing",
+                Who = MyName,
+                CombatLooting = LNS.Settings.CombatLooting,
+                CorpseRadius = LNS.Settings.CorpseRadius,
+                LootMyCorpse = LNS.Settings.LootMyCorpse,
+            })
     end
 end
 
@@ -3081,7 +3236,15 @@ function LNS.doneProcessing()
     if Mode == 'directed' then
         Logger.Info(LNS.guiLoot.console, "\ayInforming \ax\aw[\at%s\ax\aw]\ax that I am \agDone Processing.", LNS.DirectorScript)
         LNS.lootActor:send({ mailbox = 'loot_module', script = LNS.DirectorScript, },
-            { Subject = "done_processing", Who = MyName, CombatLooting = LNS.Settings.CombatLooting, })
+            {
+                Subject = "done_processing",
+                Who = MyName,
+                CombatLooting = LNS.Settings.CombatLooting,
+                CorpseRadius = LNS.Settings.CorpseRadius,
+                LootMyCorpse = LNS.Settings.LootMyCorpse,
+                IgnoreNearby = LNS.Settings.IgnoreMyNearCorpses,
+
+            })
     end
 end
 
@@ -3100,9 +3263,21 @@ function LNS.RegisterActors()
         local itemRaces     = lootMessage.races or 'All'
         local boxSettings   = lootMessage.settings or {}
         local directions    = lootMessage.directions or 'NULL'
-        local combatLooting = lootMessage.CombatLooting ~= nil and lootMessage.CombatLooting or false
-        local dbgTbl        = {}
-        dbgTbl              = {
+        local combatLooting = lootMessage.CombatLooting
+        local corpseradius  = lootMessage.CorpseRadius or LNS.Settings.CorpseRadius
+        local lootmycorpse  = lootMessage.LootMyCorpse
+        local ignorenearby  = lootMessage.IgnoreNearby
+        if ignorenearby == nil then
+            ignorenearby = LNS.Settings.IgnoreMyNearCorpses
+        end
+        if combatLooting == nil then
+            combatLooting = LNS.Settings.CombatLooting
+        end
+        if lootmycorpse == nil then
+            lootmycorpse = LNS.Settings.LootMyCorpse
+        end
+        local dbgTbl  = {}
+        dbgTbl        = {
             Lookup = 'loot.RegisterActors()',
             Event = '\ax\agReceived\ax message',
             Action = action,
@@ -3114,24 +3289,48 @@ function LNS.RegisterActors()
             Link = itemLink,
             LNS_Mode = Mode,
         }
-        if Mode == 'directed' then
-            if directions == 'doloot' and who == MyName and (LNS.Settings.DoLoot or LNS.Settings.LootMyCorpse) and not LNS.LootNow then
-                Logger.Debug(LNS.guiLoot.console, dbgTbl)
+        local infoMsg = {}
+
+        if Mode == 'directed' and who == MyName then
+            if directions == 'doloot' and (LNS.Settings.DoLoot or LNS.Settings.LootMyCorpse) and not LNS.LootNow then
+                if os.time() - (LNS.TempSettings.DirectedLoot or 0) <= 2 then
+                    LNS.TempSettings.DirectedLoot = os.time()
+                    Logger.Debug(LNS.guiLoot.console, dbgTbl)
+                end
                 LNS.LootNow = true
                 return
             end
-            if directions == 'combatlooting' then
+            if directions == 'setsetting_directed' or directions == 'combatlooting' then
+                dbgTbl['CombatLooting'] = combatLooting
+                dbgTbl['CorpseRadius'] = corpseradius
+                dbgTbl['LootMyCorpse'] = lootmycorpse
+                dbgTbl['IgnoreNearby'] = ignorenearby
+                Logger.Debug(LNS.guiLoot.console, dbgTbl)
                 LNS.Settings.CombatLooting = combatLooting
-                LNS.TempSettings.CombatLooting = combatLooting
+                LNS.Settings.CorpseRadius = corpseradius
+                LNS.Settings.LootMyCorpse = lootmycorpse
+                LNS.Settings.IgnoreMyNearCorpses = ignorenearby
+                LNS.Boxes[MyName] = LNS.Settings
+                -- LNS.writeSettings()
+                -- LNS.sendMySettings()
+                LNS.TempSettings[MyName] = nil
+                LNS.TempSettings.NeedSave = true
+            end
+            if directions == 'getsettings_directed' or direction == 'getcombatsetting' then
+                Logger.Debug(LNS.guiLoot.console, dbgTbl)
+                LNS.lootActor:send({ mailbox = 'loot_module', script = LNS.DirectorScript, },
+                    {
+                        Subject = 'mysetting',
+                        Who = MyName,
+                        CombatLooting = LNS.Settings.CombatLooting,
+                        CorpseRadius = LNS.Settings.CorpseRadius,
+                        LootMyCorpse = LNS.Settings.LootMyCorpse,
+                        IgnoreNearby = LNS.Settings.IgnoreMyNearCorpses,
+
+                    })
                 LNS.TempSettings.SentSettings = true
                 LNS.TempSettings.NeedSave = true
                 return
-            end
-            if directions == 'getcombatsetting' then
-                if Mode == 'directed' then
-                    LNS.lootActor:send({ mailbox = 'loot_module', script = LNS.DirectorScript, },
-                        { Subject = 'mysetting', Who = MyName, CombatLooting = LNS.Settings.CombatLooting, })
-                end
             end
         end
         if itemName == 'NULL' then
@@ -3146,9 +3345,6 @@ function LNS.RegisterActors()
         end
 
         if action == 'sendsettings' and who ~= MyName then
-            if LNS.Boxes[who] ~= nil and os.difftime(os.time(), LNS.TempSettings.LastSent) > 60 then
-                return
-            end
             if LNS.Boxes[who] == nil then LNS.Boxes[who] = {} end
 
             LNS.Boxes[who] = boxSettings
@@ -3170,6 +3366,26 @@ function LNS.RegisterActors()
                 LNS.TempSettings[MyName] = nil
                 LNS.TempSettings.UpdateSettings = true
             end
+        end
+
+        if action == 'addsafezone' then
+            if who == MyName then return end
+            LNS.SafeZones[lootMessage.zone] = true
+            LNS.TempSettings[MyName] = nil
+            LNS.TempSettings.UpdateSettings = true
+            Logger.Debug(LNS.guiLoot.console, dbgTbl)
+
+            return
+        end
+
+        if action == 'removesafezone' then
+            if who == MyName then return end
+            LNS.SafeZones[lootMessage.zone] = nil
+            LNS.TempSettings[MyName] = nil
+            LNS.TempSettings.UpdateSettings = true
+            Logger.Debug(LNS.guiLoot.console, dbgTbl)
+
+            return
         end
 
         if server ~= eqServer then return end
@@ -3214,20 +3430,39 @@ function LNS.RegisterActors()
                 LNS.PersonalItemsClasses[itemID] = itemClasses
                 LNS.PersonalItemsLink[itemID]    = itemLink
                 LNS.ItemNames[itemID]            = itemName
-                Logger.Info(LNS.guiLoot.console, "loot.RegisterActors: \atAction:\ax [\ay%s\ax]  \ayPersonal Rule\ax: \ag%s\ax for item \at%s\ax", action, rule, lootMessage.item)
+                infoMsg                          = {
+                    Lookup = 'loot.RegisterActors()',
+                    Action = action,
+                    RuleType = "Personal Rule",
+                    Rule = rule,
+                    Item = itemName,
+                }
             elseif section == 'GlobalItems' then
                 LNS.GlobalItemsRules[itemID]   = rule
                 LNS.GlobalItemsClasses[itemID] = itemClasses
                 LNS.GlobalItemsLink[itemID]    = itemLink
                 LNS.ItemNames[itemID]          = itemName
-                Logger.Info(LNS.guiLoot.console, "loot.RegisterActors: \atAction:\ax [\ay%s\ax] \atGlobal Rule\ax: \ag%s\ax for item \at%s\ax", action, rule, lootMessage.item)
+                infoMsg                        = {
+                    Lookup = 'loot.RegisterActors()',
+                    Action = action,
+                    RuleType = "Global Rule",
+                    Rule = rule,
+                    Item = itemName,
+                }
             elseif section == 'NormalItems' then
                 LNS.NormalItemsRules[itemID]   = rule
                 LNS.NormalItemsClasses[itemID] = itemClasses
                 LNS.NormalItemsLink[itemID]    = itemLink
                 LNS.ItemNames[itemID]          = itemName
-                Logger.Info(LNS.guiLoot.console, "loot.RegisterActors: \atAction:\ax [\ay%s\ax] \aoNormal Rule\ax: \ag%s\ax for item \at%s\ax", action, rule, itemName)
+                infoMsg                        = {
+                    Lookup = 'loot.RegisterActors()',
+                    Action = action,
+                    RuleType = "Normal Rule",
+                    Rule = rule,
+                    Item = itemName,
+                }
             end
+            Logger.Info(LNS.guiLoot.console, infoMsg)
 
             if lootMessage.entered then
                 if lootedCorpses[lootMessage.corpse] then
@@ -3248,8 +3483,14 @@ function LNS.RegisterActors()
                 else
                     LNS.NewItemsCount = 0
                 end
-                Logger.Info(LNS.guiLoot.console, "loot.RegisterActors: \atNew Item Rule \ax\agUpdated:\ax [\ay%s\ax] NewItemCount Remaining \ag%s\ax", lootMessage.entered,
-                    LNS.NewItemsCount)
+                infoMsg = {
+                    Lookup = 'loot.RegisterActors()',
+                    Action = 'New Item Rule',
+                    Updated = lootMessage.entered,
+                    NewItemCountRemaining = LNS.NewItemsCount,
+                    Item = itemName,
+                }
+                Logger.Info(LNS.guiLoot.console, infoMsg)
             end
 
             LNS.TempSettings.GetItem = { Name = itemName, ID = itemID, }
@@ -3265,7 +3506,14 @@ function LNS.RegisterActors()
             LNS[section .. 'Rules'][itemID]   = nil
             LNS[section .. 'Classes'][itemID] = nil
             LNS[section .. 'Link'][itemID]    = nil
-            Logger.Info(LNS.guiLoot.console, "loot.RegisterActors: \atAction:\ax [\ay%s\ax] \ag%s\ax rule for item \at%s\ax", action, rule, lootMessage.item)
+            infoMsg                           = {
+                Lookup = 'loot.RegisterActors()',
+                Action = action,
+                RuleType = section,
+                Rule = rule,
+                Item = itemName,
+            }
+            Logger.Info(LNS.guiLoot.console, infoMsg)
         elseif action == 'new' and who ~= MyName and LNS.NewItems[itemID] == nil then
             Logger.Debug(LNS.guiLoot.console, dbgTbl)
 
@@ -3288,7 +3536,14 @@ function LNS.RegisterActors()
                 LNS.TempSettings.NewItemIDs = {}
             end
             table.insert(LNS.TempSettings.NewItemIDs, itemID)
-            Logger.Info(LNS.guiLoot.console, "loot.RegisterActors: \atAction:\ax [\ay%s\ax] \ag%s\ax rule for item \at%s\ax", action, rule, lootMessage.item)
+            infoMsg = {
+                Lookup = 'loot.RegisterActors()',
+                Action = action,
+                RuleType = section,
+                Rule = rule,
+                Item = itemName,
+            }
+            Logger.Info(LNS.guiLoot.console, infoMsg)
             -- LNS.NewItemsCount = LNS.NewItemsCount + 1
             LNS.NewItemsCount = #LNS.TempSettings.NewItemIDs or 0
 
@@ -3316,10 +3571,11 @@ end
 ---@param cantWear boolean|nil @ Whether the character canwear the item
 function LNS.lootItem(index, doWhat, button, qKeep, cantWear)
     Logger.Debug(LNS.guiLoot.console, 'Enter lootItem')
+    local actionToTake = doWhat:gsub("%s$", "")
+    local actionLower = actionToTake:lower()
     local corpseName = mq.TLO.Corpse.CleanName() or 'none'
     local corpseItem = mq.TLO.Corpse.Item(index)
     if not corpseItem then return end
-    local curZone        = mq.TLO.Zone.ShortName() or 'none'
     local corpseItemID   = corpseItem.ID() or 0
     local itemName       = corpseItem.Name() or 'none'
     local itemLink       = corpseItem.ItemLink('CLICKABLE')()
@@ -3328,7 +3584,7 @@ function LNS.lootItem(index, doWhat, button, qKeep, cantWear)
     local corpsePos      = corpseName:find("corpse")
     local tmpLabel       = corpsePos and corpseName:sub(1, corpsePos - 4) or corpseName
     corpseName           = tmpLabel
-    local eval           = type(doWhat) == 'string' and doWhat or '?'
+    local eval           = type(actionToTake) == 'string' and actionToTake or '?'
     local dbgTbl         = {}
     dbgTbl               = {
         Lookup = 'loot.lootItem()',
@@ -3336,12 +3592,13 @@ function LNS.lootItem(index, doWhat, button, qKeep, cantWear)
         Evaluation = eval,
         Item = itemName,
         Link = itemLink,
+        Action = actionToTake,
     }
     Logger.Debug(LNS.guiLoot.console, dbgTbl)
-    if corpseItem and not shouldLootActions[doWhat] then
-        if (doWhat == 'Ignore' and not (LNS.Settings.DoDestroy and LNS.Settings.AlwaysDestroy)) or
-            (doWhat == 'Destroy' and not LNS.Settings.DoDestroy) or (doWhat == 'Ask') or (cantWear and LNS.Settings.CanWear and (corpseItem.NoDrop() or corpseItem.NoTrade())) then
-            if doWhat == ('Ask' or 'Ignore') then
+    if corpseItem and not shouldLootActions[actionToTake] then
+        if (actionLower == 'ignore' and not (LNS.Settings.DoDestroy and LNS.Settings.AlwaysDestroy)) or
+            (actionLower == 'destroy' and not LNS.Settings.DoDestroy) or (actionLower == 'ask') or (cantWear and LNS.Settings.CanWear and (corpseItem.NoDrop() or corpseItem.NoTrade())) then
+            if actionLower == 'ask' or actionLower == 'ignore' then
                 eval = 'Left'
             end
             dbgTbl = {
@@ -3354,108 +3611,104 @@ function LNS.lootItem(index, doWhat, button, qKeep, cantWear)
             Logger.Debug(LNS.guiLoot.console, dbgTbl)
 
             LNS.insertIntoHistory(itemName, corpseName, eval,
-                os.date('%Y-%m-%d'), os.date('%H:%M:%S'), itemLink, MyName, curZone, allItems, cantWear)
+                os.date('%Y-%m-%d'), os.date('%H:%M:%S'), itemLink, MyName, LNS.Zone, allItems, cantWear)
         end
         return
     end
 
-    if mq.TLO.Window('ConfirmationDialogBox').Open() then
-        Logger.Warn(LNS.guiLoot.console, "lootItem(): ConfirmationDialogBox is open. Closing it.")
-        mq.TLO.Window('ConfirmationDialogBox').DoClose()
-        mq.delay(1000, function() return not mq.TLO.Window('ConfirmationDialogBox').Open() end)
-    end
+    -- Check to see if we are allowed to loot this item
+    if shouldLootActions[actionToTake] then
+        if mq.TLO.Window('ConfirmationDialogBox').Open() then
+            Logger.Warn(LNS.guiLoot.console, "lootItem(): ConfirmationDialogBox is open. Closing it.")
+            mq.TLO.Window('ConfirmationDialogBox').DoClose()
+            mq.delay(1000, function() return not mq.TLO.Window('ConfirmationDialogBox').Open() end)
+        end
 
-    mq.cmdf('/nomodkey /shift /itemnotify loot%s %s', index, button)
-    mq.delay(1) -- Small delay to ensure command execution.
+        mq.cmdf('/nomodkey /shift /itemnotify loot%s %s', index, button)
+        mq.delay(1) -- Small delay to ensure command execution.
 
-    mq.delay(5000, function()
-        return mq.TLO.Window('ConfirmationDialogBox').Open() or mq.TLO.Cursor() ~= nil
-    end)
+        mq.delay(5000, function()
+            return mq.TLO.Window('ConfirmationDialogBox').Open() or mq.TLO.Cursor() ~= nil
+        end)
 
-    -- Handle confirmation dialog for no-drop items
-    if mq.TLO.Window('ConfirmationDialogBox').Open() then
-        mq.cmdf('/nomodkey /notify ConfirmationDialogBox Yes_Button leftmouseup')
-    end
+        -- Handle confirmation dialog for no-drop items
+        if mq.TLO.Window('ConfirmationDialogBox').Open() then
+            mq.cmdf('/nomodkey /notify ConfirmationDialogBox Yes_Button leftmouseup')
+        end
 
-    mq.delay(5000, function()
-        return mq.TLO.Cursor() ~= nil or not mq.TLO.Window('LootWnd').Open()
-    end)
+        mq.delay(5000, function()
+            return mq.TLO.Cursor() ~= nil or not mq.TLO.Window('LootWnd').Open()
+        end)
+        -- Ensure next frame processes
+        mq.delay(1)
 
-    -- Ensure next frame processes
-    mq.delay(1)
-
-    -- If loot window closes unexpectedly, exit the function
-    if not mq.TLO.Window('LootWnd').Open() then
-        -- table.insert(allItems,
-        --     { Name = itemName, Action = 'Looted', Link = itemLink, Eval = doWhat, cantWear = cantWear, CorpseName = corpseName, })
-
-        -- loot.insertIntoHistory(itemName, corpseName, doWhat,
-        --     os.date('%Y-%m-%d'), os.date('%H:%M:%S'), itemLink, MyName, curZone, allItems, cantWear)
-        return
-    end
-    Logger.Debug(LNS.guiLoot.console, string.format("eval = %s", eval))
-    if doWhat == 'Destroy' then
-        mq.delay(10000, function() return mq.TLO.Cursor.ID() == corpseItemID end)
-        eval = isGlobalItem == true and 'Global Destroy' or 'Destroy'
-        eval = isPersonalItem == true and 'Personal Destroy' or eval
+        -- If loot window closes unexpectedly, exit the function
+        if not mq.TLO.Window('LootWnd').Open() then
+            Logger.Warn(LNS.guiLoot.console, "lootItem(): Loot window closed unexpectedly. Cannot loot item: %s", itemName)
+            return
+        end
         Logger.Debug(LNS.guiLoot.console, string.format("eval = %s", eval))
+        if actionLower == 'destroy' then
+            mq.delay(10000, function() return mq.TLO.Cursor.ID() == corpseItemID end)
+            eval = isGlobalItem == true and 'Global Destroy' or 'Destroy'
+            eval = isPersonalItem == true and 'Personal Destroy' or eval
+            Logger.Debug(LNS.guiLoot.console, string.format("eval = %s", eval))
 
-        mq.cmdf('/destroy')
+            mq.cmdf('/destroy')
+            dbgTbl = {
+                Lookup = 'loot.lootItem()',
+                Check = 'Check Destroy',
+                Evaluation = eval,
+                Item = itemName,
+                Link = itemLink,
+            }
+            Logger.Debug(LNS.guiLoot.console, dbgTbl)
+        end
+
+        LNS.checkCursor()
+
+        -- Handle quest item logic
+        if qKeep == nil then qKeep = 0 end
+        if qKeep > 0 and actionLower == 'keep' then
+            eval = isGlobalItem == true and 'Global Quest' or 'Quest'
+            eval = isPersonalItem == true and 'Personal Quest' or eval
+            if type(eval) == 'boolean' then eval = 'Ask' end
+
+            local countHave = mq.TLO.FindItemCount(itemName)() + mq.TLO.FindItemBankCount(itemName)()
+            LNS.report("\awQuest Item:\ag %s \awCount:\ao %s \awof\ag %s", itemLink, tostring(countHave), qKeep)
+        else
+            Logger.Debug(LNS.guiLoot.console, string.format("eval = %s", eval))
+
+            eval = isGlobalItem == true and 'Global ' .. actionToTake or actionToTake
+            eval = isPersonalItem == true and 'Personal ' .. actionToTake or eval
+            if type(eval) == 'boolean' then eval = 'Ask' end
+
+            Logger.Debug(LNS.guiLoot.console, string.format("eval = %s", eval))
+
+            LNS.report('%sing \ay%s\ax', eval, itemLink)
+        end
+
+        if actionLower == 'ignore' then eval = 'Left' end
+        -- Log looted items
         dbgTbl = {
             Lookup = 'loot.lootItem()',
-            Check = 'Check Destroy',
+            Action = 'INSERT HISTORY',
             Evaluation = eval,
             Item = itemName,
             Link = itemLink,
         }
-        Logger.Debug(LNS.guiLoot.console, dbgTbl)
+
+        LNS.CheckBags()
+
+        -- Check for full inventory
+        if areFull == true then
+            LNS.report('My bags are full, I can\'t loot anymore! \aoOnly Looting \ayCoin\ax and Items I have \atStack Space\ax for')
+        end
+
+        Logger.Debug(LNS.guiLoot.console, "\aoINSERT HISTORY CHECK 4\ax: \ayAction\ax: \at%s\ax, Item: \ao%s\ax, \atLink: %s", eval, itemName, itemLink)
+        LNS.insertIntoHistory(itemName, corpseName, eval,
+            os.date('%Y-%m-%d'), os.date('%H:%M:%S'), itemLink, MyName, LNS.Zone, allItems, cantWear)
     end
-
-    LNS.checkCursor()
-
-    -- Handle quest item logic
-    if qKeep == nil then qKeep = 0 end
-    if qKeep > 0 and doWhat == 'Keep' then
-        eval = isGlobalItem == true and 'Global Quest' or 'Quest'
-        eval = isPersonalItem == true and 'Personal Quest' or eval
-        if type(eval) == 'boolean' then eval = 'Ask' end
-
-        local countHave = mq.TLO.FindItemCount(itemName)() + mq.TLO.FindItemBankCount(itemName)()
-        LNS.report("\awQuest Item:\ag %s \awCount:\ao %s \awof\ag %s", itemLink, tostring(countHave), qKeep)
-    else
-        Logger.Debug(LNS.guiLoot.console, string.format("eval = %s", eval))
-
-        eval = isGlobalItem == true and 'Global ' .. doWhat or doWhat
-        eval = isPersonalItem == true and 'Personal ' .. doWhat or eval
-        if type(eval) == 'boolean' then eval = 'Ask' end
-
-        Logger.Debug(LNS.guiLoot.console, string.format("eval = %s", eval))
-
-        LNS.report('%sing \ay%s\ax', eval, itemLink)
-    end
-
-    if doWhat == 'Ignore' then eval = 'Left' end
-    -- Log looted items
-    dbgTbl = {
-        Lookup = 'loot.lootItem()',
-        Action = 'INSERT HISTORY',
-        Evaluation = eval,
-        Item = itemName,
-        Link = itemLink,
-    }
-
-    LNS.insertIntoHistory(itemName, corpseName, eval,
-        os.date('%Y-%m-%d'), os.date('%H:%M:%S'), itemLink, MyName, curZone, allItems, cantWear)
-
-
-    LNS.CheckBags()
-
-    -- Check for full inventory
-    if areFull == true then
-        LNS.report('My bags are full, I can\'t loot anymore! \aoOnly Looting \ayCoin\ax and Items I have \atStack Space\ax for')
-    end
-
-    Logger.Debug(LNS.guiLoot.console, "\aoINSERT HISTORY CHECK 4\ax: \ayAction\ax: \at%s\ax, Item: \ao%s\ax, \atLink: %s", eval, itemName, itemLink)
 end
 
 function LNS.lootCorpse(corpseID)
@@ -3491,7 +3744,9 @@ function LNS.lootCorpse(corpseID)
     Logger.Debug(LNS.guiLoot.console, "lootCorpse(): Loot window open. Items: %s", items)
 
     if mq.TLO.Window('LootWnd').Open() and items > 0 then
-        if mq.TLO.Corpse.DisplayName() == mq.TLO.Me.DisplayName() then
+        local corpseName = mq.TLO.Corpse.CleanName():lower() or 'none'
+        local myCorpse = mq.TLO.Me.DisplayName():lower() .. "'s corpse"
+        if (mq.TLO.Corpse.DisplayName() == mq.TLO.Me.DisplayName()) or (corpseName == myCorpse) then
             if LNS.Settings.LootMyCorpse then
                 mq.cmdf('/lootall')
                 mq.delay("45s", function() return not mq.TLO.Window('LootWnd').Open() end)
@@ -3532,11 +3787,11 @@ function LNS.lootCorpse(corpseID)
         cantLootList[corpseID] = os.time()
     end
 
-    if #allItems > 0 then
+    if allItems ~= nil and #allItems > 0 then
         local message = {
             ID = corpseID,
             Items = allItems,
-            Zone = mq.TLO.Zone.ShortName(),
+            Zone = LNS.Zone,
             Server = eqServer,
             LootedAt = mq.TLO.Time(),
             CorpseName = corpseName,
@@ -3552,7 +3807,7 @@ function LNS.lootCorpse(corpseID)
 end
 
 function LNS.lootMobs(limit)
-    if LNS.PauseLooting then
+    if LNS.PauseLooting or LNS.SafeZones[LNS.Zone] then
         LNS.finishedLooting()
         return
     end
@@ -3616,7 +3871,7 @@ function LNS.lootMobs(limit)
     end
 
     -- Add other corpses to the loot list if not limited by the player's own corpse
-    if myCorpseCount == 0 and LNS.Settings.DoLoot then
+    if (myCorpseCount == 0 or LNS.Settings.IgnoreMyNearCorpses) and LNS.Settings.DoLoot then
         for i = 1, (limit or deadCount) do
             local corpse = mq.TLO.NearestSpawn(('%d,' .. spawnSearch):format(i, 'npccorpse', LNS.Settings.CorpseRadius))
             if corpse() and (not lootedCorpses[corpse.ID()] or not LNS.Settings.CheckCorpseOnce) then
@@ -4095,6 +4350,26 @@ function LNS.drawIcon(iconID, iconSize)
     end
 end
 
+---comment
+---@param label string Menu Item Display Label
+---@param setting_name string Setting Name in LNS.Settings
+---@param value string Setting Value in LNS.Settings
+---@param tooltip string|nil Optional Tooltip Text
+function LNS.DrawMenuItemToggle(label, setting_name, value, tooltip)
+    local changed, value = ImGui.MenuItem(label, nil, value)
+    if changed then
+        LNS.TempSettings.NeedSaveToggle = true
+        LNS.Settings[setting_name] = value
+    end
+    if tooltip then
+        if ImGui.IsItemHovered() then
+            ImGui.BeginTooltip()
+            ImGui.Text(tooltip)
+            ImGui.EndTooltip()
+        end
+    end
+end
+
 function LNS.guiExport()
     -- Define a new menu element function
     local function customMenu()
@@ -4103,43 +4378,25 @@ function LNS.guiExport()
             -- Add menu items here
             if ImGui.BeginMenu('Toggles') then
                 -- Add menu items here
-                _, LNS.Settings.DoLoot = ImGui.MenuItem("DoLoot", nil, LNS.Settings.DoLoot)
-                if _ then LNS.writeSettings() end
-                _, LNS.Settings.GlobalLootOn = ImGui.MenuItem("GlobalLootOn", nil, LNS.Settings.GlobalLootOn)
-                if _ then LNS.writeSettings() end
-                _, LNS.Settings.CombatLooting = ImGui.MenuItem("CombatLooting", nil, LNS.Settings.CombatLooting)
-                if _ then LNS.writeSettings() end
-                _, LNS.Settings.LootNoDrop = ImGui.MenuItem("LootNoDrop", nil, LNS.Settings.LootNoDrop)
-                if _ then LNS.writeSettings() end
-                _, LNS.Settings.LootNoDropNew = ImGui.MenuItem("LootNoDropNew", nil, LNS.Settings.LootNoDropNew)
-                if _ then LNS.writeSettings() end
-                _, LNS.Settings.LootForage = ImGui.MenuItem("LootForage", nil, LNS.Settings.LootForage)
-                if _ then LNS.writeSettings() end
-                _, LNS.Settings.LootQuest = ImGui.MenuItem("LootQuest", nil, LNS.Settings.LootQuest)
-                if _ then LNS.writeSettings() end
-                _, LNS.Settings.TributeKeep = ImGui.MenuItem("TributeKeep", nil, LNS.Settings.TributeKeep)
-                if _ then LNS.writeSettings() end
-                _, LNS.Settings.BankTradeskills = ImGui.MenuItem("BankTradeskills", nil, LNS.Settings.BankTradeskills)
-                if _ then LNS.writeSettings() end
-                _, LNS.Settings.StackableOnly = ImGui.MenuItem("StackableOnly", nil, LNS.Settings.StackableOnly)
-                if _ then LNS.writeSettings() end
+                LNS.DrawMenuItemToggle("DoLoot", "DoLoot", LNS.Settings.DoLoot, "Enable or disable looting of corpses.")
+                LNS.DrawMenuItemToggle("GlobalLootOn", "GlobalLootOn", LNS.Settings.GlobalLootOn, "Enable or disable global looting across all characters.")
+                LNS.DrawMenuItemToggle("CombatLooting", "CombatLooting", LNS.Settings.CombatLooting, "Enable or disable looting while in combat.")
+                LNS.DrawMenuItemToggle("LootNoDrop", "LootNoDrop", LNS.Settings.LootNoDrop, "Enable or disable looting of No Drop items.")
+                LNS.DrawMenuItemToggle("LootNoDropNew", "LootNoDropNew", LNS.Settings.LootNoDropNew, "Enable or disable looting of No Drop items with new rules.")
+                LNS.DrawMenuItemToggle("LootForage", "LootForage", LNS.Settings.LootForage, "Enable or disable looting of foraged items.")
+                LNS.DrawMenuItemToggle("LootQuest", "LootQuest", LNS.Settings.LootQuest, "Enable or disable looting of quest items.")
+                LNS.DrawMenuItemToggle("TributeKeep", "TributeKeep", LNS.Settings.TributeKeep, "Enable or disable keeping tribute items.")
+                LNS.DrawMenuItemToggle("BankTradeskills", "BankTradeskills", LNS.Settings.BankTradeskills, "Enable or disable banking of tradeskill items.")
+                LNS.DrawMenuItemToggle("StackableOnly", "StackableOnly", LNS.Settings.StackableOnly, "Enable or disable looting of only stackable items.")
                 ImGui.Separator()
-                _, LNS.Settings.AlwaysEval = ImGui.MenuItem("AlwaysEval", nil, LNS.Settings.AlwaysEval)
-                if _ then LNS.writeSettings() end
-                _, LNS.Settings.AddNewSales = ImGui.MenuItem("AddNewSales", nil, LNS.Settings.AddNewSales)
-                if _ then LNS.writeSettings() end
-                _, LNS.Settings.AddNewTributes = ImGui.MenuItem("AddNewTributes", nil, LNS.Settings.AddNewTributes)
-                if _ then LNS.writeSettings() end
-                _, LNS.Settings.AutoTag = ImGui.MenuItem("AutoTagSell", nil, LNS.Settings.AutoTag)
-                if _ then LNS.writeSettings() end
-                _, LNS.Settings.AutoRestock = ImGui.MenuItem("AutoRestock", nil, LNS.Settings.AutoRestock)
-                if _ then LNS.writeSettings() end
+                LNS.DrawMenuItemToggle("AlwaysEval", "AlwaysEval", LNS.Settings.AlwaysEval, "Enable or disable always evaluating items.")
+                LNS.DrawMenuItemToggle("AddNewSales", "AddNewSales", LNS.Settings.AddNewSales, "Enable or disable adding new sales items.")
+                LNS.DrawMenuItemToggle("AddNewTributes", "AddNewTributes", LNS.Settings.AddNewTributes, "Enable or disable adding new tribute items.")
+                LNS.DrawMenuItemToggle("AutoTagSell", "AutoTag", LNS.Settings.AutoTag, "Enable or disable automatic tagging of items for selling.")
+                LNS.DrawMenuItemToggle("AutoRestock", "AutoRestock", LNS.Settings.AutoRestock, "Enable or disable automatic restocking of items.")
                 ImGui.Separator()
-                _, LNS.Settings.DoDestroy = ImGui.MenuItem("DoDestroy", nil, LNS.Settings.DoDestroy)
-                if _ then LNS.writeSettings() end
-                _, LNS.Settings.AlwaysDestroy = ImGui.MenuItem("AlwaysDestroy", nil, LNS.Settings.AlwaysDestroy)
-                if _ then LNS.writeSettings() end
-
+                LNS.DrawMenuItemToggle("DoDestroy", "DoDestroy", LNS.Settings.DoDestroy, "Enable or disable destruction of items.")
+                LNS.DrawMenuItemToggle("AlwaysDestroy", "AlwaysDestroy", LNS.Settings.AlwaysDestroy, "Enable or disable always destroying items.")
                 ImGui.EndMenu()
             end
 
@@ -5341,6 +5598,33 @@ function LNS.drawSettingIcon(setting)
     end
 end
 
+---comment
+---@param message any Message to display in the tooltip, if a Table is passed it will display each item in the table on a new line
+---@return boolean drawn
+function LNS.DrawToolTip(message)
+    local drawn = false
+    if message == nil then return drawn end
+    if type(message) == 'table' and #message == 0 then
+        return drawn
+    end
+    ImGui.BeginTooltip()
+    if type(message) == 'table' then
+        for _, msg in ipairs(message) do
+            ImGui.PushTextWrapPos(200)
+            ImGui.Text(msg)
+            ImGui.PopTextWrapPos()
+        end
+        drawn = true
+    else
+        ImGui.PushTextWrapPos(200)
+        ImGui.Text(message)
+        ImGui.PopTextWrapPos()
+        drawn = true
+    end
+    ImGui.EndTooltip()
+    return drawn
+end
+
 ---@param id string Unique ID for the button
 ---@param value boolean Current toggle state
 ---@param on_color ImVec4|nil Color when ON default(green)
@@ -5362,6 +5646,11 @@ function LNS.DrawToggle(id, value, on_color, off_color, height, width)
 
     if label and label ~= "" then
         ImGui.Text(string.format("%s:", label))
+        if ImGui.IsItemHovered() then
+            if not LNS.DrawToolTip(LNS.Tooltips[label]) then
+                LNS.DrawToolTip(LNS.Tooltips[id:gsub("##", "")])
+            end
+        end
         ImGui.SameLine()
     end
 
@@ -5370,13 +5659,6 @@ function LNS.DrawToggle(id, value, on_color, off_color, height, width)
     local pos = { x = 0, y = 0, }
     pos.x, pos.y = ImGui.GetCursorScreenPos()
     local radius = height * 0.5
-
-    -- Set up bounding box
-    ImGui.InvisibleButton(id, width, height)
-    if ImGui.IsItemClicked() then
-        value = not value
-        clicked = true
-    end
 
     local t = value and 1.0 or 0.0
     local knob_x = pos.x + radius + t * (width - height)
@@ -5397,21 +5679,27 @@ function LNS.DrawToggle(id, value, on_color, off_color, height, width)
         0
     )
 
+    ImGui.SetCursorScreenPos(ImVec2(pos.x, pos.y))
+    -- Set up bounding box
+    ImGui.InvisibleButton(id, width, height)
+    if ImGui.IsItemClicked() then
+        value = not value
+        clicked = true
+    end
+    if ImGui.IsItemHovered() then
+        if not LNS.DrawToolTip(LNS.Tooltips[label]) then
+            LNS.DrawToolTip(LNS.Tooltips[id:gsub("##", "")])
+        end
+    end
+
     return value, clicked
 end
 
 function LNS.drawSwitch(settingName, who)
     if LNS.TempSettings[who] ~= nil then
-        -- if LNS.TempSettings[who][settingName] then
-        --     ImGui.TextColored(0.3, 1.0, 0.3, 0.9, Icons.FA_TOGGLE_ON)
-        -- else
-        --     ImGui.TextColored(1.0, 0.3, 0.3, 0.8, Icons.FA_TOGGLE_OFF)
-        -- end
         LNS.TempSettings[who][settingName] = LNS.DrawToggle("##" .. settingName, LNS.TempSettings[who][settingName],
             ImVec4(0.4, 1.0, 0.4, 0.4), ImVec4(1.0, 0.4, 0.4, 0.4))
-        if ImGui.IsItemHovered() then
-            ImGui.SetTooltip("%s %s", settingName, LNS.TempSettings[who][settingName] and "Enabled" or "Disabled")
-        end
+
         if ImGui.IsItemHovered() and ImGui.IsMouseClicked(0) then
             if LNS.Boxes[who][settingName] ~= LNS.TempSettings[who][settingName] then
                 LNS.Boxes[who][settingName] = LNS.TempSettings[who][settingName]
@@ -5440,11 +5728,6 @@ function LNS.renderSettingsSection(who)
     ImGui.SameLine()
 
     if ImGui.SmallButton("Send Settings##LootnScoot") then
-        -- if who == MyName then
-        --     -- LNS.TempSettings.UpdateSettings = true
-        --     LNS.TempSettings.SendSettings = true
-        -- end
-
         local message = {
             action = 'updatesettings',
             who = who,
@@ -5503,96 +5786,175 @@ function LNS.renderSettingsSection(who)
 
     local sorted_settings = LNS.SortTableColums(nil, LNS.TempSettings.SortedSettingsKeys, colCount / 2)
     local sorted_toggles = LNS.SortTableColums(nil, LNS.TempSettings.SortedToggleKeys, colCount / 2)
-    if ImGui.BeginTable("##Settings", colCount, bit32.bor(ImGuiTableFlags.Borders, ImGuiTableFlags.AutoResizeY, ImGuiTableFlags.Resizable)) then
-        ImGui.TableSetupScrollFreeze(colCount, 1)
-        for i = 1, colCount / 2 do
-            ImGui.TableSetupColumn("Setting", ImGuiTableColumnFlags.WidthStretch)
-            ImGui.TableSetupColumn("Value", ImGuiTableColumnFlags.WidthFixed, 80)
-        end
-        ImGui.TableHeadersRow()
+    if ImGui.CollapsingHeader(string.format("Settings %s##%s", who, who)) then
+        if ImGui.BeginTable("##Settings", colCount, bit32.bor(ImGuiTableFlags.Borders, ImGuiTableFlags.AutoResizeY, ImGuiTableFlags.Resizable)) then
+            ImGui.TableSetupScrollFreeze(colCount, 1)
+            for i = 1, colCount / 2 do
+                ImGui.TableSetupColumn("Setting", ImGuiTableColumnFlags.WidthStretch)
+                ImGui.TableSetupColumn("Value", ImGuiTableColumnFlags.WidthFixed, 80)
+            end
+            ImGui.TableHeadersRow()
 
-        for i, settingName in ipairs(sorted_settings) do
-            if settingsNoDraw[settingName] == nil or settingsNoDraw[settingName] == false then
-                if LNS.TempSettings[who] == nil then
-                    LNS.TempSettings[who] = {}
+            for i, settingName in ipairs(sorted_settings) do
+                if settingsNoDraw[settingName] == nil or settingsNoDraw[settingName] == false then
+                    if LNS.TempSettings[who] == nil then
+                        LNS.TempSettings[who] = {}
+                    end
+                    if LNS.TempSettings[who][settingName] == nil then
+                        LNS.TempSettings[who][settingName] = LNS.Boxes[who][settingName]
+                    end
+                    if type(LNS.Boxes[who][settingName]) ~= "boolean" then
+                        ImGui.PushID(settingName)
+                        ImGui.TableNextColumn()
+                        ImGui.Indent(2)
+                        ImGui.Text(settingName)
+                        if ImGui.IsItemHovered() then
+                            ImGui.BeginTooltip()
+                            ImGui.PushTextWrapPos(200)
+                            ImGui.Text("Setting: %s", settingName)
+                            ImGui.Text("%s's Current Value: %s", who, LNS.Boxes[who][settingName] and "Enabled" or "Disabled")
+                            ImGui.PopTextWrapPos()
+                            ImGui.Separator()
+                            LNS.DrawToolTip(LNS.Tooltips[settingName])
+                            ImGui.EndTooltip()
+                        end
+                        ImGui.Unindent(2)
+                        ImGui.TableNextColumn()
+                        if type(LNS.Boxes[who][settingName]) == "number" then
+                            ImGui.SetNextItemWidth(ImGui.GetColumnWidth(-1))
+
+                            LNS.TempSettings[who][settingName] = ImGui.InputInt("##" .. settingName, LNS.TempSettings[who][settingName])
+                            if LNS.Boxes[who][settingName] ~= LNS.TempSettings[who][settingName] then
+                                LNS.Boxes[who][settingName] = LNS.TempSettings[who][settingName]
+                                if who == MyName then
+                                    LNS.Settings[settingName] = LNS.Boxes[who][settingName]
+                                    LNS.TempSettings.NeedSave = true
+                                end
+                            end
+                        elseif type(LNS.Boxes[who][settingName]) == "string" then
+                            ImGui.SetNextItemWidth(ImGui.GetColumnWidth(-1))
+                            LNS.TempSettings[who][settingName] = ImGui.InputText("##" .. settingName, LNS.TempSettings[who][settingName])
+                            if LNS.Boxes[who][settingName] ~= LNS.TempSettings[who][settingName] then
+                                LNS.Boxes[who][settingName] = LNS.TempSettings[who][settingName]
+                                if who == MyName then
+                                    LNS.Settings[settingName] = LNS.Boxes[who][settingName]
+                                    LNS.TempSettings.NeedSave = true
+                                end
+                            end
+                        end
+                        if ImGui.IsItemHovered() then
+                            ImGui.BeginTooltip()
+                            ImGui.PushTextWrapPos(200)
+                            ImGui.Text("Setting: %s", settingName)
+                            ImGui.Text("%s's Current Value: %s", who, LNS.Boxes[who][settingName] and "Enabled" or "Disabled")
+                            ImGui.PopTextWrapPos()
+                            ImGui.Separator()
+                            LNS.DrawToolTip(LNS.Tooltips[settingName])
+                            ImGui.EndTooltip()
+                        end
+                        ImGui.PopID()
+                    end
                 end
-                if LNS.TempSettings[who][settingName] == nil then
-                    LNS.TempSettings[who][settingName] = LNS.Boxes[who][settingName]
+            end
+            ImGui.EndTable()
+        end
+    end
+
+    if ImGui.CollapsingHeader(string.format("Toggles %s##%s", who, who)) then
+        if ImGui.BeginTable("Toggles##1", colCount, bit32.bor(ImGuiTableFlags.Borders, ImGuiTableFlags.Resizable, ImGuiTableFlags.ScrollY)) then
+            ImGui.TableSetupScrollFreeze(colCount, 1)
+            for i = 1, colCount / 2 do
+                ImGui.TableSetupColumn("Setting", ImGuiTableColumnFlags.WidthStretch)
+                ImGui.TableSetupColumn("Value", ImGuiTableColumnFlags.WidthFixed, 80)
+            end
+            ImGui.TableHeadersRow()
+
+            for i, settingName in ipairs(sorted_toggles) do
+                if settingsNoDraw[settingName] == nil or settingsNoDraw[settingName] == false then
+                    if LNS.TempSettings[who] == nil then
+                        LNS.TempSettings[who] = {}
+                    end
+                    if LNS.TempSettings[who][settingName] == nil then
+                        LNS.TempSettings[who][settingName] = LNS.Boxes[who][settingName]
+                    end
+                    if type(LNS.Boxes[who][settingName]) == "boolean" then
+                        ImGui.PushID(settingName)
+                        ImGui.TableNextColumn()
+                        ImGui.Indent(2)
+                        -- ImGui.Text(settingName)
+                        if ImGui.Selectable(settingName) then
+                            LNS.TempSettings[who][settingName] = not LNS.TempSettings[who][settingName]
+                            if LNS.Boxes[who][settingName] ~= LNS.TempSettings[who][settingName] then
+                                LNS.Boxes[who][settingName] = LNS.TempSettings[who][settingName]
+                                if who == MyName then
+                                    LNS.Settings[settingName] = LNS.Boxes[who][settingName]
+                                    LNS.TempSettings.NeedSave = true
+                                end
+                            end
+                        end
+                        if ImGui.IsItemHovered() then
+                            ImGui.BeginTooltip()
+                            ImGui.PushTextWrapPos(200)
+                            ImGui.Text("Setting: %s", settingName)
+                            ImGui.Text("%s's Current Value: %s", who, LNS.Boxes[who][settingName] and "Enabled" or "Disabled")
+                            ImGui.PopTextWrapPos()
+                            ImGui.Separator()
+                            LNS.DrawToolTip(LNS.Tooltips[settingName])
+                            ImGui.EndTooltip()
+                        end
+                        ImGui.Unindent(2)
+                        ImGui.TableNextColumn()
+                        LNS.drawSwitch(settingName, who)
+                        ImGui.PopID()
+                    end
                 end
-                if type(LNS.Boxes[who][settingName]) ~= "boolean" then
-                    ImGui.PushID(settingName)
+            end
+            ImGui.EndTable()
+        end
+    end
+
+    if ImGui.CollapsingHeader('SafeZones##LNS') then
+        if LNS.TempSettings.NewSafeZone == nil then
+            LNS.TempSettings.NewSafeZone = ''
+        end
+        ImGui.SetNextItemWidth(150)
+        LNS.TempSettings.NewSafeZone = ImGui.InputText("New SafeZone Name", LNS.TempSettings.NewSafeZone)
+        ImGui.SameLine()
+        if ImGui.Button('Add') then
+            LNS.AddSafeZone(LNS.TempSettings.NewSafeZone)
+            LNS.TempSettings.NewSafeZone = ''
+        end
+        ImGui.SameLine()
+        if ImGui.Button("Add Current Zone") then
+            LNS.SafeZones[LNS.Zone] = true
+            LNS.AddSafeZone(LNS.Zone)
+        end
+        ImGui.Separator()
+        if ImGui.BeginTable("SafeZones", 2, bit32.bor(ImGuiTableFlags.Borders, ImGuiTableFlags.Resizable, ImGuiTableFlags.ScrollY)) then
+            ImGui.TableSetupColumn("Setting", ImGuiTableColumnFlags.WidthStretch)
+            ImGui.TableSetupColumn("Delete", ImGuiTableColumnFlags.WidthFixed, 80)
+            ImGui.TableHeadersRow()
+
+            for settingName, _ in pairs(LNS.SafeZones or {}) do
+                if settingName ~= nil then
                     ImGui.TableNextColumn()
+                    ImGui.PushID(settingName .. "SafeZone")
                     ImGui.Indent(2)
                     ImGui.Text(settingName)
                     ImGui.Unindent(2)
                     ImGui.TableNextColumn()
-                    if type(LNS.Boxes[who][settingName]) == "number" then
-                        ImGui.SetNextItemWidth(ImGui.GetColumnWidth(-1))
-
-                        LNS.TempSettings[who][settingName] = ImGui.InputInt("##" .. settingName, LNS.TempSettings[who][settingName])
-                        if LNS.Boxes[who][settingName] ~= LNS.TempSettings[who][settingName] then
-                            LNS.Boxes[who][settingName] = LNS.TempSettings[who][settingName]
-                            if who == MyName then
-                                LNS.Settings[settingName] = LNS.Boxes[who][settingName]
-                                LNS.TempSettings.NeedSave = true
-                            end
+                    if ImGui.Button("Delete##" .. settingName) then
+                        LNS.SafeZones[settingName] = nil
+                        if LNS.TempSettings.RemoveSafeZone == nil then
+                            LNS.TempSettings.RemoveSafeZone = {}
                         end
-                    elseif type(LNS.Boxes[who][settingName]) == "string" then
-                        ImGui.SetNextItemWidth(ImGui.GetColumnWidth(-1))
-                        LNS.TempSettings[who][settingName] = ImGui.InputText("##" .. settingName, LNS.TempSettings[who][settingName])
-                        if LNS.Boxes[who][settingName] ~= LNS.TempSettings[who][settingName] then
-                            LNS.Boxes[who][settingName] = LNS.TempSettings[who][settingName]
-                            if who == MyName then
-                                LNS.Settings[settingName] = LNS.Boxes[who][settingName]
-                                LNS.TempSettings.NeedSave = true
-                            end
-                        end
+                        LNS.TempSettings.RemoveSafeZone[settingName] = true
                     end
                     ImGui.PopID()
                 end
             end
+            ImGui.EndTable()
         end
-        ImGui.EndTable()
-    end
-    if ImGui.BeginTable("Toggles##1", colCount, bit32.bor(ImGuiTableFlags.Borders, ImGuiTableFlags.Resizable, ImGuiTableFlags.ScrollY)) then
-        ImGui.TableSetupScrollFreeze(colCount, 1)
-        for i = 1, colCount / 2 do
-            ImGui.TableSetupColumn("Setting", ImGuiTableColumnFlags.WidthStretch)
-            ImGui.TableSetupColumn("Value", ImGuiTableColumnFlags.WidthFixed, 80)
-        end
-        ImGui.TableHeadersRow()
-
-        for i, settingName in ipairs(sorted_toggles) do
-            if settingsNoDraw[settingName] == nil or settingsNoDraw[settingName] == false then
-                if LNS.TempSettings[who] == nil then
-                    LNS.TempSettings[who] = {}
-                end
-                if LNS.TempSettings[who][settingName] == nil then
-                    LNS.TempSettings[who][settingName] = LNS.Boxes[who][settingName]
-                end
-                if type(LNS.Boxes[who][settingName]) == "boolean" then
-                    ImGui.PushID(settingName)
-                    ImGui.TableNextColumn()
-                    ImGui.Indent(2)
-                    -- ImGui.Text(settingName)
-                    if ImGui.Selectable(settingName) then
-                        LNS.TempSettings[who][settingName] = not LNS.TempSettings[who][settingName]
-                        if LNS.Boxes[who][settingName] ~= LNS.TempSettings[who][settingName] then
-                            LNS.Boxes[who][settingName] = LNS.TempSettings[who][settingName]
-                            if who == MyName then
-                                LNS.Settings[settingName] = LNS.Boxes[who][settingName]
-                                LNS.TempSettings.NeedSave = true
-                            end
-                        end
-                    end
-                    ImGui.Unindent(2)
-                    ImGui.TableNextColumn()
-                    LNS.drawSwitch(settingName, who)
-                    ImGui.PopID()
-                end
-            end
-        end
-        ImGui.EndTable()
     end
 end
 
@@ -6052,6 +6414,7 @@ function LNS.RenderMainUI()
                 ImGui.PushStyleColor(ImGuiCol.Button, pushColor)
                 if ImGui.SmallButton(Icons.FA_BUG) then
                     debugPrint = not debugPrint
+                    Logger.Warn(LNS.guiLoot.console, "\ayDebugging\ax is now %s", debugPrint and "\agon" or "\aroff")
                 end
                 ImGui.PopStyleColor(1)
                 if ImGui.IsItemHovered() then
@@ -6256,10 +6619,18 @@ function LNS.init(args)
         'lootnscoot',
         LNS.Settings.ShowReport)
 
-    if needsSave then LNS.writeSettings() end
+    if needsSave then LNS.writeSettings("Init()") end
     if Mode == 'directed' then
         -- send them our combat setting
-        LNS.lootActor:send({ mailbox = 'loot_module', script = LNS.DirectorScript, }, { Subject = 'combatsetting', Who = MyName, CombatLooting = LNS.Settings.CombatLooting, })
+        LNS.lootActor:send({ mailbox = 'loot_module', script = LNS.DirectorScript, },
+            {
+                Subject = 'settings',
+                Who = MyName,
+                CombatLooting = LNS.Settings.CombatLooting,
+                CorpseRadius = LNS.Settings.CorpseRadius,
+                LootMyCorpse = LNS.Settings.LootMyCorpse,
+                IgnoreNearby = LNS.Settings.IgnoreMyNearCorpses,
+            })
     end
     return needsSave
 end
@@ -6276,184 +6647,245 @@ if LNS.guiLoot ~= nil then
     LNS.guiExport()
 end
 
-LNS.init({ ..., })
 
-while not LNS.Terminate do
-    local directorRunning = mq.TLO.Lua.Script(LNS.DirectorScript).Status() == 'RUNNING' or false
+function LNS.MainLoop()
+    while not LNS.Terminate do
+        local directorRunning = mq.TLO.Lua.Script(LNS.DirectorScript).Status() == 'RUNNING' or false
 
-    if not directorRunning and Mode == 'directed' then
-        LNS.Terminate = true
-    end
-
-    if mq.TLO.MacroQuest.GameState() ~= "INGAME" then LNS.Terminate = true end -- exit sctipt if at char select.
-
-    if LNS.TempSettings.LastCombatSetting == nil then
-        LNS.TempSettings.LastCombatSetting = LNS.Settings.CombatLooting
-    end
-
-    if LNS.TempSettings.LastCombatSetting ~= LNS.Settings.CombatLooting and LNS.TempSettings.NeedSave then
-        LNS.TempSettings.LastCombatSetting = LNS.Settings.CombatLooting
-        LNS.lootActor:send({ mailbox = 'loot_module', script = LNS.DirectorScript, }, { Subject = 'combatsetting', Who = MyName, CombatLooting = LNS.Settings.CombatLooting, })
-    end
-
-    if debugPrint then
-        Logger.loglevel = 'debug'
-    elseif not LNS.Settings.ShowInfoMessages then
-        Logger.loglevel = 'warn'
-    else
-        Logger.loglevel = 'info'
-    end
-
-    if (LNS.Settings.DoLoot or LNS.Settings.LootMyCorpse) and
-        (Mode ~= 'directed' or (LNS.LootNow and Mode == 'directed')) then
-        LNS.lootMobs()
-    end
-
-    if doSell then
-        LNS.processItems('Sell')
-        doSell = false
-    end
-
-    if doBuy then
-        LNS.processItems('Buy')
-        doBuy = false
-    end
-
-    if doTribute then
-        LNS.processItems('Tribute')
-        doTribute = false
-    end
-
-    if LNS.TempSettings.doBulkSet then
-        local doDelete = LNS.TempSettings.bulkDelete
-        LNS.bulkSet(LNS.TempSettings.BulkSet, LNS.TempSettings.BulkRule,
-            LNS.TempSettings.BulkClasses, LNS.TempSettings.BulkSetTable, doDelete)
-        LNS.TempSettings.doBulkSet = false
-        LNS.TempSettings.bulkDelete = false
-        LNS.TempSettings.SelectedItems = {}
-    end
-
-    if LNS.guiLoot ~= nil then
-        if LNS.guiLoot.SendHistory then
-            LNS.LoadHistoricalData()
-            LNS.guiLoot.SendHistory = false
+        if mq.TLO.Me.Zoning() then
+            lootedCorpses = {}
         end
-        if LNS.guiLoot.showReport ~= LNS.Settings.ShowReport then
-            LNS.Settings.ShowReport = LNS.guiLoot.showReport
-            LNS.TempSettings.NeedSave = true
+
+        LNS.Zone = mq.TLO.Zone.ShortName()
+
+        if LNS.TempSettings.LastZone == nil then
+            LNS.TempSettings.LastZone = 'none'
         end
-        if LNS.guiLoot.openGUI ~= LNS.Settings.ShowConsole then
-            LNS.Settings.ShowConsole = LNS.guiLoot.openGUI
-            LNS.TempSettings.NeedSave = true
+
+        if LNS.TempSettings.RemoveSafeZone ~= nil then
+            for k, v in pairs(LNS.TempSettings.RemoveSafeZone or {}) do
+                if k ~= nil then LNS.RemoveSafeZone(k) end
+            end
+            LNS.TempSettings.RemoveSafeZone = nil
         end
-        LNS.TempSettings.SessionHistory = LNS.guiLoot.SessionLootRecord or {}
-    end
 
-    mq.doevents()
-
-    if LNS.TempSettings.UpdateSettings then
-        Logger.Info(LNS.guiLoot.console, "Updating Settings")
-        mq.pickle(SettingsFile, LNS.Settings)
-        LNS.loadSettings()
-        LNS.TempSettings.UpdateSettings = false
-    end
-
-    if LNS.TempSettings.SendSettings then
-        LNS.TempSettings.SendSettings = false
-        Logger.Debug(LNS.guiLoot.console, "Sending Settings")
-        LNS.sendMySettings()
-    end
-
-    -- if LNS.TempSettings.WriteSettings then
-    --     LNS.writeSettings()
-    --     LNS.SortTables()
-    --     LNS.TempSettings.WriteSettings = false
-    -- end
-
-    if LNS.TempSettings.ClearDateData then
-        LNS.TempSettings.ClearDateData = false
-        LNS.HistoryDataDate = {}
-        LNS.HistoryItemData = {}
-    end
-
-    if LNS.TempSettings.LookUpDateData then
-        LNS.TempSettings.LookUpDateData = false
-        LNS.LoadDateHistory(lookupDate)
-        LNS.HistoryItemData = {}
-    end
-
-    if LNS.TempSettings.FindItemHistory then
-        LNS.TempSettings.FindItemHistory = false
-        if LNS.TempSettings.FilterHistory ~= nil and LNS.TempSettings.FilterHistory ~= "" then
-            LNS.LoadItemHistory(LNS.TempSettings.FilterHistory)
-            LNS.HistoryDataDate = {}
-            LNS.TempSettings.FilterHistory = ''
+        if LNS.TempSettings.LastZone ~= LNS.Zone then
+            lootedCorpses = {}
+            if LNS.SafeZones[LNS.Zone] then
+                Logger.Warn(LNS.guiLoot.console, "You are in a safe zone: \at%s\ax \ayLooting Disabled", LNS.Zone)
+            end
+            LNS.TempSettings.LastZone = LNS.Zone
         end
-    end
 
-    if LNS.TempSettings.DoGet then
-        LNS.TempSettings.DoGet = false
-        if LNS.TempSettings.GetItem == nil then return end
-        local itemName = LNS.TempSettings.GetItem.Name or 'None'
-        local itemID = LNS.TempSettings.GetItem.ID or 0
-        local db = LNS.OpenItemsSQL()
-        LNS.GetItemFromDB(itemName, itemID)
-        db:close()
-        LNS.lookupLootRule(itemID)
-        LNS.TempSettings.GetItem = nil
-    end
+        if not directorRunning and Mode == 'directed' then
+            LNS.Terminate = true
+        end
 
-    if LNS.TempSettings.NeedSave then
-        for k, v in pairs(LNS.TempSettings.UpdatedBuyItems or {}) do
-            if k ~= "" then
-                LNS.BuyItemsTable[k] = v
+        if mq.TLO.MacroQuest.GameState() ~= "INGAME" then LNS.Terminate = true end -- exit sctipt if at char select.
+
+        if LNS.TempSettings.LastCombatSetting == nil then
+            LNS.TempSettings.LastCombatSetting = LNS.Settings.CombatLooting
+        end
+
+        if LNS.TempSettings.LastCorpseRadius == nil then
+            LNS.TempSettings.LastCorpseRadius = LNS.Settings.CorpseRadius
+        end
+
+        if LNS.TempSettings.LastLootMyCorpse == nil then
+            LNS.TempSettings.LastLootMyCorpse = LNS.Settings.LootMyCorpse
+        end
+
+        if LNS.TempSettings.LastIgnoreNearby == nil then
+            LNS.TempSettings.LastIgnoreNearby = LNS.Settings.IgnoreMyNearCorpses
+        end
+
+        if LNS.TempSettings.NeedSave then
+            if (LNS.TempSettings.LastCombatSetting ~= LNS.Settings.CombatLooting) or
+                (LNS.TempSettings.LastCorpseRadius ~= LNS.Settings.CorpseRadius) or
+                (LNS.TempSettings.LastLootMyCorpse ~= LNS.Settings.LootMyCorpse) or
+                (LNS.TempSettings.LastIgnoreNearby ~= LNS.Settings.IgnoreMyNearCorpses) then
+                LNS.TempSettings.LastCombatSetting = LNS.Settings.CombatLooting
+                LNS.TempSettings.LastCorpseRadius = LNS.Settings.CorpseRadius
+                LNS.TempSettings.LastLootMyCorpse = LNS.Settings.LootMyCorpse
+                LNS.TempSettings.LastIgnoreNearby = LNS.Settings.IgnoreMyNearCorpses
+                LNS.lootActor:send({ mailbox = 'loot_module', script = LNS.DirectorScript, },
+                    {
+                        Subject = 'combatsetting',
+                        Who = MyName,
+                        CombatLooting = LNS.Settings.CombatLooting,
+                        CorpseRadius = LNS.Settings.CorpseRadius,
+                        LootMyCorpse = LNS.Settings.LootMyCorpse,
+                        IgnoreNearby = LNS.Settings.IgnoreMyNearCorpses,
+
+                    })
             end
         end
 
-        LNS.TempSettings.UpdatedBuyItems = {}
-        for k in pairs(LNS.TempSettings.DeletedBuyKeys or {}) do
-            LNS.BuyItemsTable[k] = nil
-            LNS.TempSettings.NewBuyItem = ""
-            LNS.TempSettings.NewBuyQty = 1
+        if debugPrint then
+            Logger.loglevel = 'debug'
+        elseif not LNS.Settings.ShowInfoMessages then
+            Logger.loglevel = 'warn'
+        else
+            Logger.loglevel = 'info'
         end
 
-        LNS.TempSettings.DeletedBuyKeys = {}
-        LNS.writeSettings()
-        LNS.TempSettings.NeedSave = false
-        LNS.sendMySettings()
-        LNS.SortTables()
-    end
-
-    if LNS.TempSettings.LookUpItem then
-        if LNS.TempSettings.SearchItems ~= nil and LNS.TempSettings.SearchItems ~= "" then
-            LNS.GetItemFromDB(LNS.TempSettings.SearchItems, 0)
+        if (LNS.Settings.DoLoot or LNS.Settings.LootMyCorpse) and
+            (Mode ~= 'directed' or (LNS.LootNow and Mode == 'directed')) then
+            LNS.lootMobs()
         end
-        LNS.TempSettings.LookUpItem = false
-    end
 
-    if LNS.NewItemsCount <= 0 then
-        LNS.NewItemsCount = 0
-    end
+        if doSell then
+            LNS.processItems('Sell')
+            doSell = false
+        end
 
-    if LNS.NewItemsCount == 0 then
-        showNewItem = false
-    end
+        if doBuy then
+            LNS.processItems('Buy')
+            doBuy = false
+        end
 
-    if LNS.TempSettings.NeedsCleanup and not mq.TLO.Me.Casting() then
-        LNS.TempSettings.NeedsCleanup = false
-        LNS.processItems('Destroy')
-    end
+        if doTribute then
+            LNS.processItems('Tribute')
+            doTribute = false
+        end
 
-    -- if LNS.MyClass:lower() == 'brd' and LNS.Settings.DoDestroy then
-    --     LNS.Settings.DoDestroy = false
-    --     Logger.Warn(LNS.guiLoot.console, "\ayBard Detected\ax, \arDisabling\ax [\atDoDestroy\ax].")
-    -- end
-    mq.delay(300)
+        if LNS.TempSettings.doBulkSet then
+            local doDelete = LNS.TempSettings.bulkDelete
+            LNS.bulkSet(LNS.TempSettings.BulkSet, LNS.TempSettings.BulkRule,
+                LNS.TempSettings.BulkClasses, LNS.TempSettings.BulkSetTable, doDelete)
+            LNS.TempSettings.doBulkSet = false
+            LNS.TempSettings.bulkDelete = false
+            LNS.TempSettings.SelectedItems = {}
+        end
+
+        if LNS.guiLoot ~= nil then
+            if LNS.guiLoot.SendHistory then
+                LNS.LoadHistoricalData()
+                LNS.guiLoot.SendHistory = false
+            end
+            if LNS.guiLoot.showReport ~= LNS.Settings.ShowReport then
+                LNS.Settings.ShowReport = LNS.guiLoot.showReport
+                LNS.TempSettings.NeedSave = true
+            end
+            if LNS.guiLoot.openGUI ~= LNS.Settings.ShowConsole then
+                LNS.Settings.ShowConsole = LNS.guiLoot.openGUI
+                LNS.TempSettings.NeedSave = true
+            end
+            LNS.TempSettings.SessionHistory = LNS.guiLoot.SessionLootRecord or {}
+        end
+
+        mq.doevents()
+
+        if LNS.TempSettings.UpdateSettings then
+            Logger.Info(LNS.guiLoot.console, "Updating Settings")
+            mq.pickle(SettingsFile, LNS.Settings)
+            LNS.loadSettings()
+            LNS.TempSettings.UpdateSettings = false
+        end
+
+        if LNS.TempSettings.SendSettings then
+            LNS.TempSettings.SendSettings = false
+            if os.difftime(os.time(), LNS.TempSettings.LastSent or 0) > 10 then
+                Logger.Debug(LNS.guiLoot.console, "Sending Settings")
+                LNS.sendMySettings()
+            end
+        end
+
+        -- if LNS.TempSettings.WriteSettings then
+        --     LNS.writeSettings()
+        --     LNS.SortTables()
+        --     LNS.TempSettings.WriteSettings = false
+        -- end
+
+        if LNS.TempSettings.ClearDateData then
+            LNS.TempSettings.ClearDateData = false
+            LNS.HistoryDataDate = {}
+            LNS.HistoryItemData = {}
+        end
+
+        if LNS.TempSettings.LookUpDateData then
+            LNS.TempSettings.LookUpDateData = false
+            LNS.LoadDateHistory(lookupDate)
+            LNS.HistoryItemData = {}
+        end
+
+        if LNS.TempSettings.FindItemHistory then
+            LNS.TempSettings.FindItemHistory = false
+            if LNS.TempSettings.FilterHistory ~= nil and LNS.TempSettings.FilterHistory ~= "" then
+                LNS.LoadItemHistory(LNS.TempSettings.FilterHistory)
+                LNS.HistoryDataDate = {}
+                LNS.TempSettings.FilterHistory = ''
+            end
+        end
+
+        if LNS.TempSettings.DoGet then
+            LNS.TempSettings.DoGet = false
+            if LNS.TempSettings.GetItem == nil then return end
+            local itemName = LNS.TempSettings.GetItem.Name or 'None'
+            local itemID = LNS.TempSettings.GetItem.ID or 0
+            local db = LNS.OpenItemsSQL()
+            LNS.GetItemFromDB(itemName, itemID)
+            db:close()
+            LNS.lookupLootRule(itemID)
+            LNS.TempSettings.GetItem = nil
+        end
+
+        if LNS.TempSettings.NeedSave then
+            for k, v in pairs(LNS.TempSettings.UpdatedBuyItems or {}) do
+                if k ~= "" then
+                    LNS.BuyItemsTable[k] = v
+                end
+            end
+
+            LNS.TempSettings.UpdatedBuyItems = {}
+            for k in pairs(LNS.TempSettings.DeletedBuyKeys or {}) do
+                LNS.BuyItemsTable[k] = nil
+                LNS.TempSettings.NewBuyItem = ""
+                LNS.TempSettings.NewBuyQty = 1
+            end
+
+            LNS.TempSettings.DeletedBuyKeys = {}
+            LNS.writeSettings("MainLoop()")
+            LNS.TempSettings.NeedSave = false
+            LNS.sendMySettings()
+            LNS.SortTables()
+        end
+
+        if LNS.TempSettings.LookUpItem then
+            if LNS.TempSettings.SearchItems ~= nil and LNS.TempSettings.SearchItems ~= "" then
+                LNS.GetItemFromDB(LNS.TempSettings.SearchItems, 0)
+            end
+            LNS.TempSettings.LookUpItem = false
+        end
+
+        if LNS.NewItemsCount <= 0 then
+            LNS.NewItemsCount = 0
+        end
+
+        if LNS.NewItemsCount == 0 then
+            showNewItem = false
+        end
+
+        if LNS.TempSettings.NeedsCleanup and not mq.TLO.Me.Casting() then
+            LNS.TempSettings.NeedsCleanup = false
+            LNS.processItems('Destroy')
+        end
+
+        -- if LNS.MyClass:lower() == 'brd' and LNS.Settings.DoDestroy then
+        --     LNS.Settings.DoDestroy = false
+        --     Logger.Warn(LNS.guiLoot.console, "\ayBard Detected\ax, \arDisabling\ax [\atDoDestroy\ax].")
+        -- end
+        mq.delay(300)
+    end
+    if LNS.Terminate then
+        mq.unbind("/lootutils")
+        mq.unbind("/lns")
+        mq.unbind("/looted")
+        mq.exit()
+    end
 end
 
-if LNS.Terminate then
-    mq.unbind("/lootutils")
-    mq.unbind("/lns")
-    mq.unbind("/looted")
-end
+LNS.init({ ..., })
+LNS.MainLoop()
+
 return LNS

--- a/lib/Write.lua
+++ b/lib/Write.lua
@@ -39,6 +39,17 @@ local function GetColorEnd()
     return ''
 end
 
+local function FormatTableOutput(message)
+    local output = ''
+    for k, v in pairs(message) do
+        if output ~= '' then
+            output = output .. '\n\t\t'
+        end
+        output = string.format("%s \ao%s\ax: \at%s\ax", output, k, tostring(v))
+    end
+    return output
+end
+
 local function GetCallerString()
     if Write.loglevels[Write.loglevel:lower()].level > Write.callstringlevel then
         return ''
@@ -83,11 +94,7 @@ function Write.Debug(console, message, ...)
         Output('debug', console, message)
     end
     if type(message) == 'table' then
-        local dbgMessage = ''
-        for k, v in pairs(message) do
-            dbgMessage = string.format("%s \ao%s\ax: \at%s\ax", dbgMessage, k, tostring(v))
-        end
-        Output('debug', console, dbgMessage)
+        Output('debug', console, FormatTableOutput(message))
     end
 end
 
@@ -106,6 +113,7 @@ function Write.Info(console, message, ...)
             dbgMessage = string.format("%s \ao%s\ax: \at%s\ax", dbgMessage, k, tostring(v))
         end
         Output('info', console, dbgMessage)
+        -- Output('info', console, FormatTableOutput(message))        local dbgMessage = ''
     end
 end
 
@@ -119,11 +127,7 @@ function Write.Warn(console, message, ...)
         Output('warn', console, message)
     end
     if type(message) == 'table' then
-        local dbgMessage = ''
-        for k, v in pairs(message) do
-            dbgMessage = string.format("%s \ao%s\ax: \at%s\ax", dbgMessage, k, tostring(v))
-        end
-        Output('warn', console, dbgMessage)
+        Output('warn', console, FormatTableOutput(message))
     end
 end
 
@@ -137,11 +141,7 @@ function Write.Error(console, message, ...)
         Output('error', console, message)
     end
     if type(message) == 'table' then
-        local dbgMessage = ''
-        for k, v in pairs(message) do
-            dbgMessage = string.format("%s \ao%s\ax: \at%s\ax", dbgMessage, k, tostring(v))
-        end
-        Output('error', console, dbgMessage)
+        Output('error', console, FormatTableOutput(message))
     end
 end
 
@@ -152,14 +152,10 @@ function Write.Fatal(console, message, ...)
     if type(message) == 'string' then
         if (... ~= nil) then message = string.format(message, ...) end
 
-        Output('error', console, message)
+        Output('fatal', console, message)
     end
     if type(message) == 'table' then
-        local dbgMessage = ''
-        for k, v in pairs(message) do
-            dbgMessage = string.format("%s \ao%s\ax: \at%s\ax", dbgMessage, k, tostring(v))
-        end
-        Output('error', console, dbgMessage)
+        Output('fatal', console, FormatTableOutput(message))
     end
     Terminate()
 end


### PR DESCRIPTION
* Added New setting `IgnoreMyNearCorpses` for those servers where you keep your gear on death.
* Added `SafeZones` see Settings panel We will NOT try to loot if in a `SafeZone`.
* Added Tooltips to the settings
* Added a button to the GUI to toggle Debug spam
* Another pass on directed mode.
* Another pass on loot rule checks (hopefully this fixes the occasional looting of `NoDrop` by the wrong class, looking good so far in testing)
* Performance pass on Actors messaging to cut down on how often messages are sent trimming duplicate sending.

Directed Mode Adjustments

* Added 3rd argument when launching for the scripts location (default `YourScriptName/lib/lootnscoot`) you can also just pass `lootnscoot` to have your script call LNS from its native install if it exists.
  * `/lua run ScriptPath directed DirectorName ScriptPath` where:
    * `ScriptPath` is `lootnscoot` for the standalone as arguments 1 and 3 or your bundled path.  If bundled and not specified in the 3rd argument then it defaults to  `DirectorName/lib/lootnscoot` 
    * `DirectorName` is the name of your script you are calling this from (name of folder in the lua dir)
   * If loading the default lootnscoot you should always add the 3rd field `lootnscoot`.
  * example from RGMercs Lua: In this example we also allow the user to choose which to load if they have LNS installed and the bundled version.
 ```
local Files                             = require('mq.Utils') -- has file exists function
local hasLootnScoot      = Files.File.Exists(string.format("%s/lootnscoot/init.lua", mq.luaDir)) -- check if they have lootnscoot installed
local bundleScriptPath   = string.format("rgmercs/lib/lootnscoot") -- set the bundled path
local LootScript         = "lootnscoot" -- default lootnscoot script name ie `/lua/lootnscoot` foldername
local scriptName = (Config:GetSetting('UseBundled') and hasLootnScoot) and bundleScriptPath or LootScript
mq.cmdf("/lua run %s directed rgmercs %s", scriptName, scriptName) -- call the script, by passing the 3rd argument we can use this in Actors mailbox addressing to refine the correct mailbox.
-- If you leave the 3rd one blank we will default to `DirectorName/lib/lootnscoot` if loading the default lootnscoot you should always add the 3rd field.
```
  * This should make it easier to maintain LNS in a script that is bundling it, by allowing  you to not have to bundle it
  * Saves on maintaining a copy every time LNS is updated.
* Added some more settings to be passed over actors to the `DirectingScript` so you can toggle them from both GUI's if you wanted.
