### PR TITLE
Master Loot Option

### DIFF
--- a/lib/Write.lua
+++ b/lib/Write.lua
@@ -5,13 +5,13 @@ Write.loglevel = 'info'
 Write.prefix = ''
 
 Write.loglevels = {
-    ['debug'] = { level = 1, color = '\27[95m', mqcolor = '\am', abbreviation = 'DEBUG', },
-    ['info']  = { level = 2, color = '\27[92m', mqcolor = '\ag', abbreviation = 'INFO', },
-    ['warn']  = { level = 3, color = '\27[93m', mqcolor = '\ay', abbreviation = 'WARN', },
-    ['trace'] = { level = 4, color = '\27[36m', mqcolor = '\at', abbreviation = 'TRACE', },
-    ['error'] = { level = 5, color = '\27[31m', mqcolor = '\ao', abbreviation = 'ERROR', },
-    ['fatal'] = { level = 6, color = '\27[91m', mqcolor = '\ar', abbreviation = 'FATAL', },
-    ['help']  = { level = 7, color = '\27[97m', mqcolor = '\aw', abbreviation = 'HELP', },
+    ['debug'] = { level = 1, trace = true, color = '\27[95m', mqcolor = '\am', abbreviation = 'DEBUG', },
+    ['info']  = { level = 2, trace = false, color = '\27[92m', mqcolor = '\ag', abbreviation = 'INFO', },
+    ['warn']  = { level = 3, trace = true, color = '\27[93m', mqcolor = '\ay', abbreviation = 'WARN', },
+    ['trace'] = { level = 4, trace = true, color = '\27[36m', mqcolor = '\at', abbreviation = 'TRACE', },
+    ['error'] = { level = 5, trace = true, color = '\27[31m', mqcolor = '\ao', abbreviation = 'ERROR', },
+    ['fatal'] = { level = 6, trace = true, color = '\27[91m', mqcolor = '\ar', abbreviation = 'FATAL', },
+    ['help']  = { level = 7, trace = false, color = '\27[97m', mqcolor = '\aw', abbreviation = 'HELP', },
 }
 
 Write.callstringlevel = Write.loglevels['debug'].level
@@ -52,7 +52,7 @@ local function FormatTableOutput(message)
 end
 
 local function GetCallerString()
-    if Write.loglevels[Write.loglevel:lower()].level > Write.callstringlevel then
+    if not Write.loglevels[Write.loglevel:lower()].trace or (not Write.loglevels[Write.loglevel:lower()].trace and Write.loglevel ~= 'debug') then
         return ''
     end
 


### PR DESCRIPTION
* You can enable `MasterLooting` in the settings or through `/lns set` command
* Changing the setting on one char will tell the others to match
* When MasterLooting is on we will report back any items not marked as ignore or destroy.
* the items will appear in a new window showing some basic information about the item,
* clicking on the item name will open its link in game
* the members column will list people from actors and how many of the item they have
* clicking the `loot` button next to a name will tell that person to loot the correct mob and one of those items
* users will nav to the corpse and attempt to loot one of the item specified.
* You can also dismiss an item form the list (may reappear on next corpse if another drops, you can set it to ignore to prevent reappearances)
* There is also a `Self Loot` button to just loot the item yourself.

