### PR TITLE
Refactor database usage

### DIFF
--- a/performance.lua
+++ b/performance.lua
@@ -1,0 +1,136 @@
+-- Ripped from rgmercs/derple
+local mq                  = require('mq')
+local ImPlot              = require('ImPlot')
+local Set                 = require('mq.Set')
+local ScrollingPlotBuffer = require('scrolling_plot_buffer')
+
+local Module              = { _version = '0.1a', _name = "Perf", _author = 'Derple', }
+Module.__index            = Module
+Module.DefaultConfig      = {}
+Module.MaxFrameStep       = 5.0
+Module.GoalMaxFrameTime   = 0
+Module.CurMaxMaxFrameTime = 0
+Module.xAxes              = {}
+Module.SettingsLoaded     = false
+Module.FrameTimingData    = {}
+Module.MaxFrameTime       = 0
+Module.LastExtentsCheck   = os.clock()
+Module.FAQ                = {}
+Module.SaveRequested      = nil
+Module.SecondsToStore     = 30
+Module.EnablePerfMonitoring = false
+Module.PlotFillLines      = true
+
+Module.DefaultConfig      = {
+    ['SecondsToStore']                         = {
+        DisplayName = "Seconds to Store",
+        Group = "General",
+        Header = "Misc",
+        Category = "Misc",
+        Tooltip = "The number of Seconds to keep in history.",
+        Default = 30,
+        Min = 10,
+        Max = 120,
+        Step = 5,
+    },
+    ['EnablePerfMonitoring']                   = {
+        DisplayName = "Enable Performance Monitoring",
+        Group       = "General",
+        Header      = "Misc",
+        Category    = "Misc",
+        Tooltip     = "Enable the Performance Module for advanced testing.",
+        Default     = false,
+    },
+    ['PlotFillLines']                          = {
+        DisplayName = "Enable Fill Lines",
+        Group = "General",
+        Header = "Misc",
+        Category = "Misc",
+        Tooltip = "Fill in the Plot Lines",
+        Default = true,
+    },
+}
+
+function Module.New()
+    local newModule = setmetatable({}, Module)
+    return newModule
+end
+
+function Module:Init()
+    return { self = self, defaults = self.DefaultConfig, }
+end
+
+function Module:ShouldRender()
+    return Module.EnablePerfMonitoring
+end
+
+function Module:Render()
+    local pressed
+
+    if os.clock() - self.LastExtentsCheck > 0.01 then
+        self.GoalMaxFrameTime = 0
+        self.LastExtentsCheck = os.clock()
+        for _, data in pairs(self.FrameTimingData) do
+            for idx, time in ipairs(data.frameTimes.DataY) do
+                -- is this entry visible?
+                local visible = data.frameTimes.DataX[idx] > os.clock() - Module.SecondsToStore and
+                    data.frameTimes.DataX[idx] < os.clock()
+                if visible and time > self.GoalMaxFrameTime then
+                    self.GoalMaxFrameTime = math.ceil(time / self.MaxFrameStep) * self.MaxFrameStep
+                end
+            end
+        end
+    end
+
+    -- converge on new max recalc min and maxes
+    if self.CurMaxMaxFrameTime < self.GoalMaxFrameTime then self.CurMaxMaxFrameTime = self.CurMaxMaxFrameTime + 1 end
+    if self.CurMaxMaxFrameTime > self.GoalMaxFrameTime then self.CurMaxMaxFrameTime = self.CurMaxMaxFrameTime - 1 end
+
+    if ImPlot.BeginPlot("Frame Times for LootNScoot") then
+        ImPlot.SetupAxes("Time (s)", "Frame Time (ms)")
+        ImPlot.SetupAxisLimits(ImAxis.X1, os.clock() - Module.SecondsToStore, os.clock(), ImGuiCond.Always)
+        ImPlot.SetupAxisLimits(ImAxis.Y1, 1, self.CurMaxMaxFrameTime, ImGuiCond.Always)
+
+        for _, module in pairs({'lootitem','history'}) do
+            if self.FrameTimingData[module] and not self.FrameTimingData[module].mutexLock then
+                local framData = self.FrameTimingData[module]
+
+                if framData then
+                    ImPlot.PlotLine(module, framData.frameTimes.DataX, framData.frameTimes.DataY,
+                        #framData.frameTimes.DataX,
+                        Module.PlotFillLines and ImPlotLineFlags.Shaded or ImPlotLineFlags.None,
+                        framData.frameTimes.Offset - 1)
+                end
+            end
+        end
+
+        ImPlot.EndPlot()
+    end
+end
+
+function Module:GiveTime(combat_state)
+end
+
+function Module:OnFrameExec(module, frameTime)
+    if not Module.EnablePerfMonitoring then return end
+
+    if not self.FrameTimingData[module] then
+        self.FrameTimingData[module] = {
+            mutexLock = false,
+            lastFrame = os.clock(),
+            frameTimes =
+                ScrollingPlotBuffer:new(),
+        }
+    end
+
+    self.FrameTimingData[module].lastFrame = os.clock()
+    self.FrameTimingData[module].frameTimes:AddPoint(os.clock(), frameTime)
+end
+
+function Module:DoGetState()
+    if not Module.EnablePerfMonitoring then return "Disabled" end
+
+    return "Enabled"
+end
+
+return Module

--- a/scrolling_plot_buffer.lua
+++ b/scrolling_plot_buffer.lua
@@ -1,0 +1,46 @@
+-- Ripped from rgmercs/derple
+---@diagnostic disable: duplicate-doc-field
+-- Global
+---@class ScrollingPlotBuffer
+---@field MaxSize number
+---@field Offset number
+---@field DataX number[]
+---@field DataY number[]
+
+local ScrollingPlotBuffer = {}
+
+---@param max_size? number
+---@return ScrollingPlotBuffer
+function ScrollingPlotBuffer:new(max_size)
+    max_size = max_size or 2000
+    local newObject = setmetatable({}, self)
+    self.__index = self
+    newObject.MaxSize = max_size
+    newObject.Offset = 1
+    newObject.DataX = {}
+    newObject.DataY = {}
+    return newObject
+end
+
+---@param x number
+---@param y number
+function ScrollingPlotBuffer:AddPoint(x, y)
+    if #self.DataX < self.MaxSize then
+        table.insert(self.DataX, x)
+        table.insert(self.DataY, y)
+    else
+        self.DataX[self.Offset] = x
+        self.DataY[self.Offset] = y
+        self.Offset = self.Offset + 1
+        if self.Offset > self.MaxSize then
+            self.Offset = 1
+        end
+    end
+end
+
+function ScrollingPlotBuffer:Erase()
+    self.DataX = {}
+    self.DataY = {}
+end
+
+return ScrollingPlotBuffer


### PR DESCRIPTION
- Open each of items, rules, history DB once at launch of script.
  - Remove db:close() calls everywhere.
  - Why? Don't see a need to keep opening and closing the database around every operation.
- Prepare frequently used statements once at start of script.
  - INSERT INTO ITEMS
  - SELECT FROM LootHistory
  - INSERT INTO LootHistory
  - INSERT INTO Normal_Rules
  - INSERT INTO Global_Rules
  - INSERT INTO PersonalRulesTable
  - SELECT FROM Normal_Rules
  - SELECT FROM Global_Rules
  - SELECT FROM PersonalRulesTable
  - Replace prepared statement finalize calls with reset where applicable.
  - Why? The point of creating a prepared statement is that it will be a frequently used statement. It defeats the purpose to prepare it every time it is going to be used.
- Remove transactions from any statements that are not writes.
  - Why? Just adding unnecessary overhead.
- Remove transactions from some individual write statements.
  - Why? Transactions are meant for making multiple writes that need to go together atomic.
- Remove wal_checkpoint from non-write statements.
  - Why? Not sure why it would be necessary after select statements.
- Remove wal_checkpoint from history tracking writes.
  - Writing the database on every history insert nearly defeats the purpose of using wal at all. Inserting history records shouldn't be a critical operation that needs to be written back to the database immediately.

Also added a setting TrackHistory (default=true) so that reporting / history tracking can be toggled off.  
Also consolidated loreItems and noDropItems into skippedLoots and reporting all skipped items together.

Also borrowed performance monitor from rgmercs to show times for lootItem and inserting item history.