### PR TITLE
consolidate tables

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "mq-defs.etag": "W/\"609c81f50081776b14f6a7c1a7dd73d4062bceed0c3c321e33d4a50a80d466de\""
+  "mq-defs.etag": "W/\"1cc79d8d7ff6995106260496216a6552a29930c91a506c465606eafb20574dd0\""
 }

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ All configs, tables, etc are kept separate between the new version and the old. 
 - A new rules DB accounts for using item IDs. Unfortunately, this invalidates the old rules table since we never had the ID data.
 - NEW Rules Section (Personal Rules)
   - This is a per character set of rules for items.
-  - These rules will override all other rule sets. 
-  - Order of Authority `Personal > Global > Normal`
+  - These rules will override all other rule sets.
+  - Order of Authority `Personal > Global`
 
 ### Config and DB Locations
 - **Config Files:**
@@ -105,8 +105,6 @@ All configs, tables, etc are kept separate between the new version and the old. 
  - You can edit any characters settings from the window, clicking save will send them the new settings and they will save them.
  - You can clone a characters settings from one char to another. making setting up new groups easier.
 - Added `IgnoreBagSlot` setting. setting this will ignore anything in that slot\bag when it comes to selling\tributeing\banking\cleanup.
-- AlwaysGlobal: (default off)
- - This will also make a global rule for new items when looting and when acknowledging the new item rules. 
 
 ### COMMANDS
 - `/lns` or `/lootutils`

--- a/docs/actor-messaging-diagram.md
+++ b/docs/actor-messaging-diagram.md
@@ -151,14 +151,6 @@ sequenceDiagram
             CharC->>CharC: Update GlobalItemsRules[itemID]
         end
         
-        alt Normal Rule
-            Actors-->>CharB: Receive addrule (Normal)
-            CharB->>CharB: Update NormalItemsRules[itemID]
-            CharB->>CharB: Get item from DB
-            Actors-->>CharC: Receive addrule (Normal)
-            CharC->>CharC: Update NormalItemsRules[itemID]
-        end
-        
         alt Rule is Destroy
             CharB->>CharB: Mark NeedsCleanup = true
             CharC->>CharC: Mark NeedsCleanup = true
@@ -389,7 +381,6 @@ sequenceDiagram
 ### Rule Distribution
 - Personal rules: Stay local (not broadcast)
 - Global rules: Shared with all characters
-- Normal rules: Shared with all characters (unless AlwaysGlobal)
 - Bulk operations use reloadrules for efficiency
 
 ### New Item Discovery

--- a/docs/database-updates-diagram.md
+++ b/docs/database-updates-diagram.md
@@ -17,7 +17,6 @@ sequenceDiagram
     DB->>ItemsDB: CREATE INDEX idx_item_id
     
     DB->>RulesDB: CREATE TABLE Global_Rules
-    DB->>RulesDB: CREATE TABLE Normal_Rules
     DB->>RulesDB: CREATE TABLE Personal_Rules
     DB->>RulesDB: CREATE TABLE SafeZones
     DB->>RulesDB: CREATE TABLE WildCards
@@ -59,9 +58,7 @@ sequenceDiagram
         LNS->>DB: UpsertItemRule(action, tableName, itemName, itemID, classes, link)
         DB->>RulesDB: BEGIN TRANSACTION
         
-        alt Normal Rules
-            DB->>RulesDB: INSERT INTO Normal_Rules ... ON CONFLICT DO UPDATE
-        else Global Rules
+        alt Global Rules
             DB->>RulesDB: INSERT INTO Global_Rules ... ON CONFLICT DO UPDATE
         else Personal Rules
             DB->>RulesDB: INSERT INTO Personal_Rules ... ON CONFLICT DO UPDATE
@@ -193,29 +190,19 @@ sequenceDiagram
         LNS->>DB: ImportOldRulesDB(path)
         DB->>DB: Open old database file
         DB->>DB: Load Global_Rules with negative IDs
-        DB->>DB: Load Normal_Rules with negative IDs
-        
+
         DB->>ItemsDB: ResolveItemIDs(nameSet)
         Note over DB,ItemsDB: Match item names to real IDs
         ItemsDB-->>DB: Resolved ID mappings
-        
+
         DB->>RulesDB: BEGIN TRANSACTION
-        
+
         loop For each Global Rule
             alt Real ID found
                 DB->>RulesDB: INSERT INTO Global_Rules (real_id, ...)
             else No ID match
                 DB->>RulesDB: INSERT INTO Global_Rules (negative_id, ...)
                 DB->>DB: Add to GlobalItemsMissing
-            end
-        end
-        
-        loop For each Normal Rule
-            alt Real ID found
-                DB->>RulesDB: INSERT INTO Normal_Rules (real_id, ...)
-            else No ID match
-                DB->>RulesDB: INSERT INTO Normal_Rules (negative_id, ...)
-                DB->>DB: Add to NormalItemsMissing
             end
         end
         

--- a/docs/looting-sequence-diagram.md
+++ b/docs/looting-sequence-diagram.md
@@ -127,7 +127,7 @@ sequenceDiagram
 - Reports skipped items
 
 ### getRule()
-- Looks up existing loot rules from database (Personal > Global > Normal)
+- Looks up existing loot rules from database (Personal > Global)
 - Applies auto-rules for new items if configured
 - Validates lore items (already have?)
 - Checks nodrop settings
@@ -146,7 +146,7 @@ sequenceDiagram
 - Reports to console/chat
 
 ### Database Checks
-- lookupLootRule: Checks Personal_Rules > Global_Rules > Normal_Rules
+- lookupLootRule: Checks Personal_Rules > Global_Rules
 - CheckRulesDB: Queries SQLite database for item rules
 - insertIntoHistory: Records looted/ignored items with timestamp
 

--- a/init.lua
+++ b/init.lua
@@ -15,6 +15,12 @@ local settings        = require('modules.settings')
 local ui              = require('modules.ui')
 -- local MasterLooter = require('MasterLooter')
 
+-- check for Nav
+if not mq.TLO.Plugin("MQ2Nav").IsLoaded() then
+    print("\arWARNING!!\ax \ayMQ2Nav\ax is \arNOT\ax loaded. \ayPlease Load `/plugin Nav` and try again.")
+    mq.exit()
+end
+
 if not success then
     printf('\arERROR: Write.lua could not be loaded\n%s\ax', Logger)
     return
@@ -51,12 +57,6 @@ local validActions                      = {
 local NEVER_SELL                        = { ['Diamond Coin'] = true, ['Celestial Crest'] = true, ['Gold Coin'] = true, ['Taelosian Symbols'] = true, ['Planar Symbols'] = true, }
 
 local doSell, doBuy, doTribute, areFull = false, false, false, false
-
--- local SECTIONS = {
---     ['NormalItems']='Normal_Rules',
---     ['GlobalItems']='Global_Rules',
---     ['PersonalItems']=settings.PersonalTableName,
--- }
 
 local equipSlots                        = {
     [0] = 'Charm',
@@ -115,13 +115,9 @@ LNS.CurrentPage            = LNS.CurrentPage or 1
 LNS.BuyItemsTable          = {}
 LNS.ALLITEMS               = {}
 LNS.GlobalItemsRules       = {}
-LNS.NormalItemsRules       = {}
-LNS.NormalItemsClasses     = {}
 LNS.GlobalItemsClasses     = {}
-LNS.NormalItemsMissing     = {}
 LNS.GlobalItemsMissing     = {}
 LNS.GlobalMissingNames     = {}
-LNS.NormalMissingNames     = {}
 LNS.HasMissingItems        = false
 LNS.NewItems               = {}
 LNS.PersonalItemsRules     = {}
@@ -360,9 +356,7 @@ end
 function LNS.SortTables()
     settings.TempSettings.SortedGlobalItemKeys     = {}
     settings.TempSettings.SortedBuyItemKeys        = {}
-    settings.TempSettings.SortedNormalItemKeys     = {}
     settings.TempSettings.SortedMissingGlobalNames = {}
-    settings.TempSettings.SortedMissingNormalNames = {}
 
     for k in pairs(LNS.GlobalItemsRules) do
         table.insert(settings.TempSettings.SortedGlobalItemKeys, k)
@@ -374,11 +368,6 @@ function LNS.SortTables()
     end
     table.sort(settings.TempSettings.SortedBuyItemKeys, function(a, b) return a < b end)
 
-    for k in pairs(LNS.NormalItemsRules) do
-        table.insert(settings.TempSettings.SortedNormalItemKeys, k)
-    end
-    table.sort(settings.TempSettings.SortedNormalItemKeys, function(a, b) return a < b end)
-
     local tmpTbl = {}
     for name, id in pairs(LNS.GlobalMissingNames) do
         table.insert(tmpTbl, { name = name, id = id, })
@@ -387,16 +376,6 @@ function LNS.SortTables()
         return a.name < b.name
     end)
     settings.TempSettings.SortedMissingGlobalNames = tmpTbl
-
-
-    tmpTbl = {}
-    for name, id in pairs(LNS.NormalMissingNames) do
-        table.insert(tmpTbl, { name = name, id = id, })
-    end
-    table.sort(tmpTbl, function(a, b)
-        return a.name < b.name
-    end)
-    settings.TempSettings.SortedMissingNormalNames = tmpTbl
 end
 
 function LNS.SortKeys(input_table)
@@ -451,9 +430,7 @@ end
 function LNS.loadSettings(firstRun)
     if firstRun == nil then firstRun = false end
     if firstRun then
-        LNS.NormalItemsRules     = {}
         LNS.GlobalItemsRules     = {}
-        LNS.NormalItemsClasses   = {}
         LNS.GlobalItemsClasses   = {}
         LNS.ItemLinks            = {}
         LNS.BuyItemsTable        = {}
@@ -762,10 +739,7 @@ function LNS.commandHandler(...)
         end
     end
     if args[1] == 'lowest' then
-        local normal_low = db.GetLowestID('Normal_Rules') or 0
         local global_low = db.GetLowestID('Global_Rules') or 0
-        -- local personal_low = db.GetLowestID(string.format('%s_Rules', settings.MyName)) or 0
-        Logger.Info(LNS.guiLoot.console, string.format("Lowest Normal Item ID: \ay%s\ax", normal_low or 'None'))
         Logger.Info(LNS.guiLoot.console, string.format("Lowest Global Item ID: \ay%s\ax", global_low or 'None'))
         -- Logger.Info(LNS.guiLoot.console, "Lowest Personal Item ID: \ay%s\ax", personal_low or 'None')
 
@@ -863,21 +837,17 @@ function LNS.commandHandler(...)
             if not item() and args[3] then
                 local itemID = LNS.resolveItemIDbyName(args[3], false)
                 if itemID then
-                    LNS.addRule(itemID, 'NormalItems', rule, 'All', 'NULL')
+                    LNS.addRule(itemID, 'GlobalItems', rule, 'All', 'NULL')
                     Logger.Info(LNS.guiLoot.console, "Setting \ay%s\ax to \ay%s\ax", args[3], rule)
                 else
-                    -- get lowest item ID from the table multiply times -1 and subtract one to make a unique negative ID
-                    -- local newID = db.GetLowestID('Normal_Rules') or -1
-                    LNS.EnterNegIDRule(args[3], rule, 'All', 'NULL', 'Normal_Rules')
-                    -- then add rule as a missing item for now.
-                    -- LNS.addRule(newID, 'NormalItems', rule, 'All', 'NULL')
+                    LNS.EnterNegIDRule(args[3], rule, 'All', 'NULL', 'Global_Rules')
 
                     Logger.Warn(LNS.guiLoot.console, "Item \ar%s\ax not found in DB. adding rule as a missing item.", args[3])
                 end
             end
             if item() then
                 local itemID = item.ID()
-                LNS.addRule(itemID, 'NormalItems', rule, 'All', item.ItemLink('CLICKABLE')())
+                LNS.addRule(itemID, 'GlobalItems', rule, 'All', item.ItemLink('CLICKABLE')())
                 Logger.Info(LNS.guiLoot.console, "Setting \ay%s\ax to \ay%s\ax", item.Name(), rule)
             end
             return
@@ -961,12 +931,12 @@ function LNS.commandHandler(...)
             LNS.markTradeSkillAsBank()
         elseif validActions[command] and item() then
             local itemID = item.ID()
-            LNS.addRule(itemID, 'NormalItems', validActions[command], 'All', item.ItemLink('CLICKABLE')())
+            LNS.addRule(itemID, 'GlobalItems', validActions[command], 'All', item.ItemLink('CLICKABLE')())
             Logger.Info(LNS.guiLoot.console, "Setting \ay%s\ax to \ay%s\ax", item.Name(), validActions[command])
         elseif string.find(command, "quest%|") and item() then
             local itemID = item.ID()
             local val    = string.gsub(command, "quest", "Quest")
-            LNS.addRule(itemID, 'NormalItems', val, 'All', item.ItemLink('CLICKABLE')())
+            LNS.addRule(itemID, 'GlobalItems', val, 'All', item.ItemLink('CLICKABLE')())
             Logger.Info(LNS.guiLoot.console, "Setting \ay%s\ax to \ay%s\ax", item.Name(), val)
         elseif command == 'quit' or command == 'exit' then
             printf('LootNScoot stopping due to quit command received.')
@@ -990,7 +960,7 @@ function LNS.commandHandler(...)
             Logger.Debug(LNS.guiLoot.console, "lootID: %s", lootID)
             if lootID then
                 if LNS.ALLITEMS[lootID] then
-                    LNS.addRule(lootID, 'NormalItems', validActions[action], 'All', LNS.ALLITEMS[lootID].Link)
+                    LNS.addRule(lootID, 'GlobalItems', validActions[action], 'All', LNS.ALLITEMS[lootID].Link)
                     Logger.Info(LNS.guiLoot.console, "Setting \ay%s (%s)\ax to \ay%s\ax", item_name, lootID, validActions[action])
                 end
             end
@@ -1126,7 +1096,7 @@ function LNS.enterNewItemRuleInfo(data_table)
     local modMessage = {
         who        = settings.MyName,
         action     = 'modifyitem',
-        section    = "NormalItems",
+        section    = "GlobalItems",
         item       = item,
         itemID     = itemID,
         rule       = rule,
@@ -1137,7 +1107,7 @@ function LNS.enterNewItemRuleInfo(data_table)
         hasChanged = false,
         Server     = settings.EqServer,
     }
-    if (classes ~= (LNS.NormalItemsClasses[itemID] or 'new') or rule ~= (LNS.NormalItemsRules[itemID] or 'new')) and rule ~= 'Ignore' and rule ~= 'Ask' then
+    if (classes ~= (LNS.GlobalItemsClasses[itemID] or 'new') or rule ~= (LNS.GlobalItemsRules[itemID] or 'new')) and rule ~= 'Ignore' and rule ~= 'Ask' then
         modMessage.hasChanged = true
         dbgTbl = {
             Check  = 'loot.enterNewItemRuleInfo() \ax\agChanges Made to Item:',
@@ -1163,9 +1133,6 @@ function LNS.enterNewItemRuleInfo(data_table)
         Logger.Debug(LNS.guiLoot.console, dbgTbl)
     end
 
-    if settings.Settings.AlwaysGlobal then
-        modMessage.section = "GlobalItems"
-    end
     actors.Send(modMessage)
 end
 
@@ -1184,16 +1151,6 @@ function LNS.EnterNegIDRule(itemName, rule, classes, link, tableName)
                 item_classes = classes,
             }
             LNS.GlobalMissingNames[itemName] = newID
-        elseif tableName == 'Normal_Rules' then
-            LNS.NormalItemsRules[newID] = rule
-            LNS.NormalItemsClasses[newID] = classes
-            LNS.NormalItemsMissing[newID] = {
-                item_id      = newID,
-                item_name    = itemName,
-                item_rule    = rule,
-                item_classes = classes,
-            }
-            LNS.NormalMissingNames[itemName] = newID
         end
         LNS.enterNewItemRuleInfo({
             ID       = newID,
@@ -1689,7 +1646,7 @@ function LNS.lookupLootRule(mq_item, itemID, tablename, item_link, skipWildcard)
     if itemID == nil or itemID == 0 then
         return 'NULL', 'All', 'NULL', 'None'
     end
-    local which_table = 'Normal'
+    local which_table = 'Global'
     local iData = {}
     _, iData = LNS.findItem(nil, itemID)
 
@@ -1722,34 +1679,6 @@ function LNS.lookupLootRule(mq_item, itemID, tablename, item_link, skipWildcard)
             end
             return LNS.GlobalItemsRules[itemID], LNS.GlobalItemsClasses[itemID], LNS.ItemLinks[itemID], 'Global'
         end
-        if LNS.NormalItemsRules[itemID] then
-            if link ~= 'NULL' or (item_link and link ~= item_link) then
-                LNS.UpdateRuleLink(itemID, LNS.ItemLinks[itemID], 'Normal_Rules')
-            end
-            return LNS.NormalItemsRules[itemID], LNS.NormalItemsClasses[itemID], LNS.ItemLinks[itemID], 'Normal'
-        end
-        -- Never called with a tablename
-        -- elseif tablename == 'Global_Rules' then
-        --     if LNS.GlobalItemsRules[itemID] then
-        --         if link ~= 'NULL' or (item_link and link ~= item_link) then
-        --             LNS.UpdateRuleLink(itemID, LNS.ItemLinks[itemID], 'Global_Rules')
-        --         end
-        --         return LNS.GlobalItemsRules[itemID], LNS.GlobalItemsClasses[itemID], LNS.ItemLinks[itemID], 'Global'
-        --     end
-        -- elseif tablename == 'Normal_Rules' then
-        --     if LNS.NormalItemsRules[itemID] then
-        --         if link ~= 'NULL' or (item_link and link ~= item_link) then
-        --             LNS.UpdateRuleLink(itemID, LNS.ItemLinks[itemID], 'Normal_Rules')
-        --         end
-        --         return LNS.NormalItemsRules[itemID], LNS.NormalItemsClasses[itemID], LNS.ItemLinks[itemID], 'Normal'
-        --     end
-        -- elseif tablename == settings.PersonalTableName then
-        --     if LNS.PersonalItemsRules[itemID] then
-        --         if link ~= 'NULL' or (item_link and link ~= item_link) then
-        --             LNS.UpdateRuleLink(itemID, LNS.ItemLinks[itemID], settings.PersonalTableName)
-        --         end
-        --         return LNS.PersonalItemsRules[itemID], LNS.PersonalItemsClasses[itemID], LNS.ItemLinks[itemID], 'Personal'
-        --     end
     end
 
     local rule       = 'NULL'
@@ -1767,12 +1696,6 @@ function LNS.lookupLootRule(mq_item, itemID, tablename, item_link, skipWildcard)
             which_table = 'Global'
             tablename = 'Global_Rules'
         end
-        if not found then
-            found, rule, classes, lookupLink = db.CheckRulesDB(itemID, db.PreparedStatements.CHECK_DB_NORMAL)
-            which_table = 'Normal'
-            tablename = 'Normal_Rules'
-        end
-
         if not found and not skipWildcard then
             if mq_item and mq_item() then
                 local wildCardRule = LNS.CheckWildCards(mq_item.Name()) or ''
@@ -1780,7 +1703,7 @@ function LNS.lookupLootRule(mq_item, itemID, tablename, item_link, skipWildcard)
                     classes       = classes ~= 'NULL' and classes or 'All'
                     lookupLink    = item_link
                     found         = true
-                    which_table   = 'Normal'
+                    which_table   = 'Global'
                     rule          = wildCardRule
 
                     local addToDB = true
@@ -1804,7 +1727,7 @@ function LNS.lookupLootRule(mq_item, itemID, tablename, item_link, skipWildcard)
     -- if SQL has the item add the rules to the lua table for next time
 
     if rule ~= 'NULL' then
-        local localTblName                     = tablename == 'Global_Rules' and 'GlobalItems' or 'NormalItems'
+        local localTblName                     = 'GlobalItems'
         localTblName                           = tablename == settings.PersonalTableName and 'PersonalItems' or localTblName
 
         LNS[localTblName .. 'Rules'][itemID]   = rule
@@ -2059,14 +1982,10 @@ function LNS.addNewItem(corpseItem, itemRule, itemLink, corpseID, addDB)
     }
 
     Logger.Info(LNS.guiLoot.console, "\agAdding 1 \ayNEW\ax item: \at%s \ay(\axID: \at%s\at) \axwith rule: \ag%s", itemName, itemID, itemRule)
-    -- LNS.actorAddRule(itemID, itemName, 'Normal', itemRule, LNS.TempItemClasses, itemLink)
     if addDB then
-        LNS.addRule(itemID, 'NormalItems', itemRule, LNS.TempItemClasses, itemLink, true)
+        LNS.addRule(itemID, 'GlobalItems', itemRule, LNS.TempItemClasses, itemLink, true)
     end
-    local sections = { NormalItems = 1, }
-    if settings.Settings.AlwaysGlobal then
-        sections['GlobalItems'] = 1
-    end
+    local sections = { GlobalItems = 1, }
     newMessage.sections = sections
     actors.Send(newMessage)
 end
@@ -2086,8 +2005,10 @@ function LNS.modifyItemRule(itemID, action, tableName, classes, link, skipMsg)
         return
     end
 
-    local section = tableName == "Normal_Rules" and "NormalItems" or "GlobalItems"
-    section = tableName == settings.PersonalTableName and 'PersonalItems' or section
+    local section = "GlobalItems"
+    if tableName == settings.PersonalTableName then
+        section = 'PersonalItems'
+    end
     -- Validate RulesDB
     if not db.RulesDB or type(db.RulesDB) ~= "string" then
         Logger.Warn(LNS.guiLoot.console, "Invalid RulesDB path: %s", tostring(db.RulesDB))
@@ -2115,21 +2036,12 @@ function LNS.modifyItemRule(itemID, action, tableName, classes, link, skipMsg)
     local success = false
     if action == 'delete' then
         success = db.DeleteItemRule(action, tableName, itemName, itemID)
-        if settings.Settings.AlwaysGlobal and section == 'NormalItems' then
-            success = db.DeleteItemRule(action, 'Global_Rules', itemName, itemID)
-        end
     else
         success = db.UpsertItemRule(action, tableName, itemName, itemID, classes, link)
-        if settings.Settings.AlwaysGlobal and section == 'NormalItems' then
-            success = db.UpsertItemRule(action, 'Global_Rules', itemName, itemID, classes, link)
-        end
     end
 
     if success and not skipMsg then
         local sections = { section = 1, }
-        if settings.Settings.AlwaysGlobal and section == 'NormalItems' then
-            sections['GlobalItems'] = 1
-        end
         -- Notify other actors about the rule change
         actors.Send({
             who      = settings.MyName,
@@ -2182,19 +2094,11 @@ function LNS.addRule(itemID, section, rule, classes, link, skipMsg)
     LNS[section .. "Classes"][itemID] = classes
     LNS.ItemLinks[itemID]             = link
 
-    if settings.Settings.AlwaysGlobal and section == 'NormalItems' then
-        LNS["GlobalItemsRules"][itemID]   = rule
-        LNS["GlobalItemsClasses"][itemID] = classes
-    end
-
-    local tblName = section == 'GlobalItems' and 'Global_Rules' or 'Normal_Rules'
+    local tblName                     = 'Global_Rules'
     if section == 'PersonalItems' then
         tblName = settings.PersonalTableName
     end
     LNS.modifyItemRule(itemID, rule, tblName, classes, link, skipMsg)
-    -- if settings.Settings.AlwaysGlobal and section == 'NormalItems' then
-    --     LNS.modifyItemRule(itemID, rule, 'Global_Rules', classes, link, true)
-    -- end
 
     -- Refresh the loot settings to apply the changes
     return true
@@ -2411,7 +2315,7 @@ function LNS.checkWearable(isEquippable, decision, ruletype, nodrop, newrule, is
             end
         end
     else
-        if nodrop and settings.Settings.CanWear and ruletype == 'Normal' and not isAug then
+        if nodrop and settings.Settings.CanWear and ruletype == 'Global' and not isAug then
             decision = 'Ignore'
             iCanWear = false
         end
@@ -2576,30 +2480,13 @@ function LNS.getRule(item, fromFunction, index)
             end
         end
     end
-    if LNS.NormalMissingNames[itemName] then
-        if LNS.findItem(itemName) == 1 then
-            local negID = LNS.NormalMissingNames[itemName] or 0
-            if negID < 0 then
-                LNS.modifyItemRule(itemID,
-                    LNS.NormalItemsMissing[negID].item_rule,
-                    'Normal_Rules',
-                    LNS.NormalItemsMissing[negID].item_classes,
-                    itemLink)
-
-                Logger.Info(LNS.guiLoot.console, "\arItem \ax%s\ar is missing from the database. Re-adding with \ayImported rule\ax: \ag%s\ax",
-                    itemName, LNS.NormalItemsMissing[negID].item_rule)
-                LNS.NormalMissingNames[itemName] = nil
-                LNS.NormalItemsMissing[negID] = nil
-            end
-        end
-    end
     -- Lookup existing rule in the databases
 
     local lootRule, lootClasses, lootLink, ruletype = LNS.lookupLootRule(item, itemID, nil, itemLink, false)
     Logger.Debug(LNS.guiLoot.console, "\ax\ao Lookup Rule \axItem: (\at%s\ax) ID: (\ag%s\ax) Rule: (\ay%s\ax) Classes: (\at%s\ax)",
         itemName, itemID, lootRule, lootClasses)
     -- check for always eval
-    if settings.Settings.AlwaysEval and ruletype == 'Normal' then
+    if settings.Settings.AlwaysEval and ruletype == 'Global' then
         if lootRule ~= "Quest" and lootRule ~= "Keep" and lootRule ~= "Destroy" and lootRule ~= 'CanUse' and lootRule ~= 'Ask' and lootRule ~= 'Bank' then
             lootRule = 'NULL'
         end
@@ -2613,7 +2500,7 @@ function LNS.getRule(item, fromFunction, index)
     if newRule then
         Logger.Info(LNS.guiLoot.console, "\ax\ag NEW RULE Detected!\ax Item: (\at%s\ax)", itemName, lootRule)
         lootClasses = LNS.retrieveClassList(item)
-        ruletype = 'Normal'
+        ruletype = 'Global'
         local addToDB = true
         lootRule = "Ask"
 
@@ -2766,7 +2653,7 @@ function LNS.getRule(item, fromFunction, index)
         iCanUse, lootDecision = LNS.checkWearable(isEquippable, lootRule, ruletype, isNoDrop, newRule, isAug, item)
     end
 
-    if ((lootRule == 'Sell' or lootRule == 'Tribute') and ruletype == 'Normal') then
+    if ((lootRule == 'Sell' or lootRule == 'Tribute') and ruletype == 'Global') then
         Logger.Debug(LNS.guiLoot.console, "\ax\ag Checking Decision for \aySELL\ax or \ayTRIBUTE\ax: \at%s\ax", lootRule)
         lootDecision = LNS.checkDecision(item, lootRule)
     end
@@ -2788,7 +2675,7 @@ function LNS.getRule(item, fromFunction, index)
     end
 
     -- Handle augments
-    if settings.Settings.LootAugments and isAug and ruletype == 'Normal' and not settings.Settings.MasterLooting then
+    if settings.Settings.LootAugments and isAug and ruletype == 'Global' and not settings.Settings.MasterLooting then
         lootDecision = "Keep"
         dbgTbl = {
             Lookup = '\ax\ag Check for AUGMENTS',
@@ -2802,7 +2689,7 @@ function LNS.getRule(item, fromFunction, index)
     end
 
     -- Handle Spell Drops
-    if settings.Settings.KeepSpells and LNS.checkSpells(itemName) and ruletype == 'Normal' and not settings.Settings.MasterLooting then
+    if settings.Settings.KeepSpells and LNS.checkSpells(itemName) and ruletype == 'Global' and not settings.Settings.MasterLooting then
         lootDecision = "Keep"
         dbgTbl = {
             Lookup = '\ax\ag Check for SPELLS',
@@ -2860,9 +2747,25 @@ function LNS.getRule(item, fromFunction, index)
 end
 
 function LNS.setBuyItem(itemName, qty)
+    if settings.TempSettings.BuyItems == nil then
+        settings.TempSettings.BuyItems = {}
+    end
     settings.TempSettings.BuyItems[itemName] = { Key = itemName, Value = qty, }
     settings.Settings.BuyItemsTable[itemName] = qty
     LNS.BuyItemsTable[itemName] = qty
+end
+
+-- Broadcasts a buy item to all other characters so they add it to their own buy lists
+function LNS.shareBuyItemToOthers(itemName, qty)
+    if not itemName or itemName == '' then return end
+    actors.Send({
+        who    = settings.MyName,
+        Server = settings.EqServer,
+        action = 'share_buy_item',
+        item   = itemName,
+        qty    = qty or 1,
+    })
+    Logger.Info(LNS.guiLoot.console, "\agShared\ax buy item \at%s\ax (qty: \ay%s\ax) to other characters.", itemName, qty or 1)
 end
 
 -- Sets a Global Item rule
@@ -2883,23 +2786,6 @@ function LNS.setGlobalItem(itemID, val, classes, link)
     end
 end
 
--- Sets a Normal Item rule
-function LNS.setNormalItem(itemID, val, classes, link)
-    if itemID == nil then
-        Logger.Warn(LNS.guiLoot.console, "Invalid itemID for setNormalItem.")
-        return
-    end
-    LNS.NormalItemsRules[itemID] = val ~= 'delete' and val or nil
-    if val ~= 'delete' then
-        LNS.NormalItemsClasses[itemID] = classes or 'All'
-        LNS.ItemLinks[itemID]          = link or (LNS.ItemLinks[itemID] or 'NULL')
-    else
-        LNS.NormalItemsClasses[itemID] = nil
-        LNS.NormalItemsMissing[settings.TempSettings.ModifyItemID] = nil
-    end
-    LNS.modifyItemRule(itemID, val, 'Normal_Rules', classes, link)
-end
-
 function LNS.setPersonalItem(itemID, val, classes, link)
     if itemID == nil then
         Logger.Warn(LNS.guiLoot.console, "Invalid itemID for setPersonalItem.")
@@ -2913,6 +2799,26 @@ function LNS.setPersonalItem(itemID, val, classes, link)
         LNS.PersonalItemsClasses[itemID] = nil
     end
     LNS.modifyItemRule(itemID, val, settings.PersonalTableName, classes, link)
+end
+
+-- Broadcasts a personal rule to all other characters so they set it in their own personal tables
+function LNS.sharePersonalRuleToOthers(itemID, rule, classes, link)
+    if itemID == nil then return end
+    local itemName = LNS.ItemNames[itemID] or 'Unknown'
+    classes = classes or 'All'
+    link = link or LNS.ItemLinks[itemID] or 'NULL'
+    actors.Send({
+        who     = settings.MyName,
+        Server  = settings.EqServer,
+        action  = 'share_personal_rule',
+        item    = itemName,
+        itemID  = itemID,
+        rule    = rule,
+        section = 'PersonalItems',
+        link    = link,
+        classes = classes,
+    })
+    Logger.Info(LNS.guiLoot.console, "\agShared\ax personal rule for \at%s\ax (\ay%s\ax) to other characters.", itemName, rule)
 end
 
 function LNS.GetTableSize(tbl)
@@ -2960,8 +2866,8 @@ function LNS.lootItem(mq_item, index, doWhat, button, qKeep, cantWear)
     corpseName           = tmpLabel
     local eval           = type(actionToTake) == 'string' and actionToTake or '?'
     local dbgTbl         = {}
-    local rule           = isGlobalItem and LNS.GlobalItemsRules[cItemID] or
-        (isPersonalItem and LNS.PersonalItemsRules[cItemID] or (LNS.NormalItemsRules[cItemID] or nil))
+    local rule           = isPersonalItem and LNS.PersonalItemsRules[cItemID] or
+        (isGlobalItem and LNS.GlobalItemsRules[cItemID] or nil)
     if allItems == nil then allItems = {} end
     dbgTbl = {
         Lookup = 'loot.lootItem()',
@@ -3640,7 +3546,7 @@ function LNS.eventSell(_, itemName)
 
     if settings.Settings.AddNewSales then
         -- Add a rule to mark the item as "Sell"
-        LNS.addRule(itemID, "NormalItems", "Sell", "All", 'NULL')
+        LNS.addRule(itemID, "GlobalItems", "Sell", "All", 'NULL')
         Logger.Info(LNS.guiLoot.console, "Added rule: \ay%s\ax set to \agSell\ax.", itemName)
     end
 end
@@ -3711,8 +3617,8 @@ function LNS.markTradeSkillAsBank()
     for i = 1, 10 do
         local bagSlot = mq.TLO.InvSlot('pack' .. i).Item
         if bagSlot.ID() and bagSlot.Tradeskills() then
-            LNS.NormalItemsRules[bagSlot.ID()] = 'Bank'
-            LNS.addRule(bagSlot.ID(), 'NormalItems', 'Bank', 'All', bagSlot.ItemLink('CLICKABLE')())
+            LNS.GlobalItemsRules[bagSlot.ID()] = 'Bank'
+            LNS.addRule(bagSlot.ID(), 'GlobalItems', 'Bank', 'All', bagSlot.ItemLink('CLICKABLE')())
         end
     end
 end
@@ -3811,7 +3717,7 @@ function LNS.eventTribute(_, itemName)
     end
     if settings.Settings.AddNewTributes then
         -- Add a rule to mark the item as "Tribute"
-        LNS.addRule(itemID, "NormalItems", "Tribute", "All", link)
+        LNS.addRule(itemID, "GlobalItems", "Tribute", "All", link)
         Logger.Info(LNS.guiLoot.console, "Added rule: \ay%s\ax set to \agTribute\ax.", itemName)
     end
 end
@@ -3913,7 +3819,7 @@ function LNS.processItems(action)
         if not item or not item.ID() then return end
         local itemID     = item.ID()
         local tradeskill = item.Tradeskills()
-        local rule       = LNS.NormalItemsRules[itemID] or "Ignore"
+        local rule       = LNS.GlobalItemsRules[itemID] or "Ignore"
         if LNS.PersonalItemsRules[itemID] then
             rule = LNS.PersonalItemsRules[itemID]
         elseif LNS.GlobalItemsRules[itemID] then

--- a/modules/actor.lua
+++ b/modules/actor.lua
@@ -30,7 +30,7 @@ local function callback(message)
     local action        = lootMessage.action or ''
     local itemID        = lootMessage.itemID or 0
     local rule          = lootMessage.rule or 'NULL'
-    local section       = lootMessage.section or 'NormalItems'
+    local section       = lootMessage.section or 'GlobalItems'
     local sections      = lootMessage.sections
     local itemName      = lootMessage.item or 'NULL'
     local itemLink      = lootMessage.link or 'NULL'
@@ -334,6 +334,42 @@ local function callback(message)
         LNS.ItemLinks                           = lootMessage.bulkLink or {}
         return
     end
+    -- Handle shared personal rule from another character
+    if action == 'share_personal_rule' and who ~= settings.MyName then
+        Logger.Debug(guiLoot.console, dbgTbl)
+        LNS.ItemNames[itemID] = itemName
+        LNS.setPersonalItem(itemID, rule, itemClasses, itemLink)
+        Logger.Info(guiLoot.console, {
+            Lookup = 'loot.RegisterActors()',
+            Action = action,
+            RuleType = "Shared Personal Rule",
+            Classes = itemClasses,
+            Rule = rule,
+            Item = itemName,
+            From = who,
+        })
+        return
+    end
+
+    -- Handle shared buy item from another character
+    if action == 'share_buy_item' and who ~= settings.MyName then
+        Logger.Debug(guiLoot.console, dbgTbl)
+        local buyName = lootMessage.item or ''
+        local buyQty = lootMessage.qty or 1
+        if buyName ~= '' then
+            LNS.setBuyItem(buyName, buyQty)
+            settings.TempSettings.NeedSave = true
+            Logger.Info(guiLoot.console, {
+                Lookup = 'loot.RegisterActors()',
+                Action = action,
+                Item = buyName,
+                Qty = buyQty,
+                From = who,
+            })
+        end
+        return
+    end
+
     -- -- Handle actions
 
     if action == 'addrule' or action == 'modifyitem' or (action == 'new' and sections ~= nil) then
@@ -361,19 +397,6 @@ local function callback(message)
                 Lookup = 'loot.RegisterActors()',
                 Action = action,
                 RuleType = "Global Rule",
-                Classes = itemClasses,
-                Rule = rule,
-                Item = itemName,
-            }
-        elseif (section == 'NormalItems' or (sections and sections['NormalItems'])) and who ~= settings.MyName then
-            LNS.NormalItemsRules[itemID]   = rule
-            LNS.NormalItemsClasses[itemID] = itemClasses
-            LNS.ItemLinks[itemID]          = itemLink
-            LNS.ItemNames[itemID]          = itemName
-            infoMsg                        = {
-                Lookup = 'loot.RegisterActors()',
-                Action = action,
-                RuleType = "Normal Rule",
                 Classes = itemClasses,
                 Rule = rule,
                 Item = itemName,

--- a/modules/db.lua
+++ b/modules/db.lua
@@ -145,16 +145,6 @@ ORDER BY Date DESC, TimeStamp DESC LIMIT 1
 INSERT INTO LootHistory (Item, CorpseName, Action, Date, TimeStamp, Link, Looter, Zone)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 ]])
-    initPreparedStatement('INSERT_RULE_NORMAL', rules_db, [[
-INSERT INTO Normal_Rules
-(item_id, item_name, item_rule, item_rule_classes, item_link)
-VALUES (?, ?, ?, ?, ?)
-ON CONFLICT(item_id) DO UPDATE SET
-item_name                                    = excluded.item_name,
-item_rule                                    = excluded.item_rule,
-item_rule_classes                                    = excluded.item_rule_classes,
-item_link                                    = excluded.item_link
-]])
     initPreparedStatement('INSERT_RULE_GLOBAL', rules_db, [[
 INSERT INTO Global_Rules
 (item_id, item_name, item_rule, item_rule_classes, item_link)
@@ -176,12 +166,9 @@ item_rule_classes                                    = excluded.item_rule_classe
 item_link                                    = excluded.item_link
 ]], settings.PersonalTableName))
     initPreparedStatement('CHECK_DB_PERSONAL', rules_db, string.format("SELECT item_rule, item_rule_classes, item_link FROM %s WHERE item_id = ?", settings.PersonalTableName))
-    initPreparedStatement('CHECK_DB_NORMAL', rules_db, "SELECT item_rule, item_rule_classes, item_link FROM Normal_Rules WHERE item_id = ?")
     initPreparedStatement('CHECK_DB_GLOBAL', rules_db, "SELECT item_rule, item_rule_classes, item_link FROM Global_Rules WHERE item_id = ?")
-    initPreparedStatement('GET_ITEM_LINK_NORMAL', rules_db, "SELECT item_link FROM Normal_Rules WHERE item_id = ?")
     initPreparedStatement('GET_ITEM_LINK_GLOBAL', rules_db, "SELECT item_link FROM Global_Rules WHERE item_id = ?")
     initPreparedStatement('GET_ITEM_LINK_PERSONAL', rules_db, string.format("SELECT item_link FROM %s WHERE item_id = ?", settings.PersonalTableName))
-    initPreparedStatement('UPDATE_RULE_LINK_NORMAL', rules_db, "UPDATE Normal_Rules SET item_link = ? WHERE item_id = ?")
     initPreparedStatement('UPDATE_RULE_LINK_GLOBAL', rules_db, "UPDATE Global_Rules SET item_link = ? WHERE item_id = ?")
     initPreparedStatement('UPDATE_RULE_LINK_PERSONAL', rules_db, string.format("UPDATE %s SET item_link = ? WHERE item_id = ?", settings.PersonalTableName))
 end
@@ -619,18 +606,12 @@ end
 --- RULES DB
 
 function LNS_DB.LoadRuleDB()
-    if rules_db == nil then LNS_DB.OpenDB(LNS_DB.RulesDB) end
+    if rules_db == nil then rules_db = LNS_DB.OpenDB(LNS_DB.RulesDB) end
+    LNS_DB.MigrateNormalToGlobal()
     -- Creating tables
     rules_db:exec(string.format([[
 BEGIN TRANSACTION;
 CREATE TABLE IF NOT EXISTS Global_Rules (
-item_id INTEGER PRIMARY KEY NOT NULL UNIQUE,
-item_name TEXT NOT NULL,
-item_rule TEXT NOT NULL,
-item_rule_classes TEXT,
-item_link TEXT
-);
-CREATE TABLE IF NOT EXISTS Normal_Rules (
 item_id INTEGER PRIMARY KEY NOT NULL UNIQUE,
 item_name TEXT NOT NULL,
 item_rule TEXT NOT NULL,
@@ -674,7 +655,7 @@ PRAGMA wal_checkpoint;
         end
     end
 
-    for _, tbl in ipairs({ "Global_Rules", "Normal_Rules", settings.PersonalTableName, }) do
+    for _, tbl in ipairs({ "Global_Rules", settings.PersonalTableName, }) do
         local stmt = rules_db:prepare("SELECT * FROM " .. tbl)
         local lbl = tbl:gsub("_Rules", "")
         if tbl == settings.PersonalTableName then lbl = 'Personal' end
@@ -715,6 +696,75 @@ function LNS_DB.LoadWildCardRules()
     return Wc_Table
 end
 
+--- Migrate Normal_Rules into Global_Rules (one-time migration).
+--- Normal_Rules entries are inserted into Global_Rules only where the item_id
+--- does not already exist in Global_Rules (Global wins on conflicts).
+--- After migration the Normal_Rules table is dropped.
+---@return boolean true if migration ran, false if already migrated
+function LNS_DB.MigrateNormalToGlobal()
+    if rules_db == nil then rules_db = LNS_DB.OpenDB(LNS_DB.RulesDB) end
+
+    -- Check if Normal_Rules table exists
+    local exists = false
+    local check_stmt = rules_db:prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='Normal_Rules'")
+    if check_stmt then
+        if check_stmt:step() == SQLite3.ROW then
+            exists = true
+        end
+        check_stmt:finalize()
+    end
+
+    if not exists then
+        Logger.Debug(guiLoot.console, "Normal_Rules table not found - migration already complete.")
+        return false
+    end
+
+    -- Count entries before migration
+    local normalCount = 0
+    local count_stmt = rules_db:prepare("SELECT COUNT(*) as cnt FROM Normal_Rules")
+    if count_stmt then
+        if count_stmt:step() == SQLite3.ROW then
+            normalCount = count_stmt:get_value(0)
+        end
+        count_stmt:finalize()
+    end
+
+    -- Ensure Global_Rules table exists before migrating into it
+    rules_db:exec([[
+CREATE TABLE IF NOT EXISTS Global_Rules (
+item_id INTEGER PRIMARY KEY NOT NULL UNIQUE,
+item_name TEXT NOT NULL,
+item_rule TEXT NOT NULL,
+item_rule_classes TEXT,
+item_link TEXT
+);
+]])
+
+    -- Insert Normal_Rules entries into Global_Rules where item_id does not already exist
+    local migrated = rules_db:exec([[
+INSERT INTO Global_Rules (item_id, item_name, item_rule, item_rule_classes, item_link)
+SELECT item_id, item_name, item_rule, item_rule_classes, item_link
+FROM Normal_Rules
+WHERE item_id NOT IN (SELECT item_id FROM Global_Rules);
+]])
+
+    if migrated ~= SQLite3.OK then
+        Logger.Error(guiLoot.console,
+            "\arFailed to migrate Normal_Rules into Global_Rules: %s", rules_db:errmsg())
+        return false
+    end
+
+    -- Drop the old table
+    rules_db:exec("DROP TABLE Normal_Rules;")
+    rules_db:exec("PRAGMA wal_checkpoint;")
+
+    Logger.Info(guiLoot.console,
+        "\agMigration complete\ax: merged \ay%d\ax Normal_Rules entries into Global_Rules (Global wins on conflicts). Normal_Rules table dropped.",
+        normalCount)
+    return true
+end
+
 ---comment
 ---@param item_table table Index of ItemId's to set
 ---@param setting any Setting to set all items to
@@ -724,7 +774,7 @@ end
 function LNS_DB.BulkSet(item_table, setting, classes, which_table, delete_items)
     if item_table == nil or type(item_table) ~= "table" then return end
     if which_table == 'Personal_Rules' then which_table = settings.PersonalTableName end
-    local localName = which_table == 'Normal_Rules' and 'NormalItems' or 'GlobalItems'
+    local localName = 'GlobalItems'
     localName = which_table == settings.PersonalTableName and 'PersonalItems' or localName
     if rules_db == nil then LNS_DB.OpenDB(LNS_DB.RulesDB) end
 
@@ -795,10 +845,8 @@ function LNS_DB.GetItemLink(itemID, link, which_table)
 
     -- local qry = string.format([[UPDATE %s SET item_link = ? WHERE item_id = ?;]], which_table)
     -- local stmt = rules_db:prepare(qry)
-    local stmt = LNS_DB.PreparedStatements.GET_ITEM_LINK_NORMAL
-    if which_table == 'Global_Rules' then
-        stmt = LNS_DB.PreparedStatements.GET_ITEM_LINK_GLOBAL
-    elseif which_table == settings.PersonalTableName then
+    local stmt = LNS_DB.PreparedStatements.GET_ITEM_LINK_GLOBAL
+    if which_table == settings.PersonalTableName then
         stmt = LNS_DB.PreparedStatements.GET_ITEM_LINK_PERSONAL
     end
     -- if not stmt then
@@ -823,10 +871,8 @@ function LNS_DB.UpdateRuleLink(itemID, link, which_table)
     -- if not stmt then
     --     return
     -- end
-    local stmt = LNS_DB.PreparedStatements.UPDATE_RULE_LINK_NORMAL
-    if which_table == 'Global_Rules' then
-        stmt = LNS_DB.PreparedStatements.UPDATE_RULE_LINK_GLOBAL
-    elseif which_table == settings.PersonalTableName then
+    local stmt = LNS_DB.PreparedStatements.UPDATE_RULE_LINK_GLOBAL
+    if which_table == settings.PersonalTableName then
         stmt = LNS_DB.PreparedStatements.UPDATE_RULE_LINK_PERSONAL
     end
     stmt:bind_values(link, itemID)
@@ -897,9 +943,7 @@ function LNS_DB.UpsertItemRule(action, tableName, itemName, itemID, classes, lin
 
     local stmt
     -- UPSERT operation
-    if tableName == 'Normal_Rules' then
-        stmt = LNS_DB.PreparedStatements.INSERT_RULE_NORMAL
-    elseif tableName == 'Global_Rules' then
+    if tableName == 'Global_Rules' then
         stmt = LNS_DB.PreparedStatements.INSERT_RULE_GLOBAL
     else
         stmt = LNS_DB.PreparedStatements.INSERT_RULE_PERSONAL
@@ -1082,9 +1126,7 @@ function LNS_DB.ImportOldRulesDB(path)
     end
 
     local tmpGlobalDB = {}
-    local tmpNormalDB = {}
     local tmpNamesGlobal = {}
-    local tmpNamesNormal = {}
 
     db:exec("PRAGMA journal_mode=WAL;")
     local query = "SELECT * From Global_Rules;"
@@ -1102,29 +1144,31 @@ function LNS_DB.ImportOldRulesDB(path)
         cntr = cntr + 1
     end
 
+    -- Merge Normal_Rules into Global (Global wins on conflicts)
     query = "SELECT * From Normal_Rules;"
     stmt = db:prepare(query)
-    cntr = 1
-    for row in stmt:nrows() do
-        local itemID = cntr * -1
-
-        tmpNormalDB[itemID] = {
-            item_id      = itemID,
-            item_name    = row.item_name,
-            item_rule    = row.item_rule,
-            item_classes = row.item_classes or 'All',
-        }
-        tmpNamesNormal[row.item_name] = itemID
-        cntr = cntr + 1
+    if stmt then
+        for row in stmt:nrows() do
+            if not tmpNamesGlobal[row.item_name] then
+                local itemID = cntr * -1
+                tmpGlobalDB[itemID] = {
+                    item_id      = itemID,
+                    item_name    = row.item_name,
+                    item_rule    = row.item_rule,
+                    item_classes = row.item_classes or 'All',
+                }
+                tmpNamesGlobal[row.item_name] = itemID
+                cntr = cntr + 1
+            end
+        end
+        stmt:finalize()
     end
-    stmt:finalize()
 
     db:close()
 
 
     local nameSet = {}
     for _, v in pairs(tmpGlobalDB) do nameSet[v.item_name] = true end
-    for _, v in pairs(tmpNormalDB) do nameSet[v.item_name] = true end
 
     -- Resolve IDs in one DB pass
     local resolvedNames = LNS_DB.ResolveItemIDs(nameSet)
@@ -1145,22 +1189,7 @@ function LNS_DB.ImportOldRulesDB(path)
     end
     tmpGlobalDB = newGlobal
 
-    local newNormal = {}
-    -- Replace IDs for tmpNormalDB
-    for k, v in pairs(tmpNormalDB) do
-        local realID = resolvedNames[v.item_name]
-        local id = realID or v.item_id
-        if id < 0 then LNS.HasMissingItems = true end
-        newNormal[id] = {
-            item_id = id,
-            item_name = v.item_name,
-            item_rule = v.item_rule,
-            item_classes = v.item_classes,
-        }
-    end
-
-    tmpNormalDB = newNormal
-    if rules_db == nil then LNS_DB.OpenDB(LNS_DB.RulesDB) end
+    if rules_db == nil then rules_db = LNS_DB.OpenDB(LNS_DB.RulesDB) end
 
     -- insert into the current rules DB
     local qry = string.format([[
@@ -1196,39 +1225,6 @@ item_link = excluded.item_link
             if itemID > 0 then tmpGlobalDB[itemID] = nil end
         end
     end
-
-    qry = string.format([[
-INSERT INTO Normal_Rules (item_id, item_name, item_rule, item_rule_classes, item_link)
-VALUES (?, ?, ?, ?, ?)
-ON CONFLICT(item_id) DO UPDATE SET
-item_name = excluded.item_name,
-item_rule = excluded.item_rule,
-item_rule_classes = excluded.item_rule_classes,
-item_link = excluded.item_link
-]])
-
-    stmt = rules_db:prepare(qry)
-    if not stmt then
-        rules_db:exec("COMMIT;")
-        rules_db:exec("PRAGMA wal_checkpoint;")
-        return
-    end
-
-    for itemID, data in pairs(tmpNormalDB or {}) do
-        local itemName = data.item_name
-        local itemLink = LNS.ItemLinks[itemID] or 'NULL'
-        local classes = data.item_classes or 'All'
-        local rule = data.item_rule or 'Ask'
-        if itemName then
-            stmt:bind_values(itemID, itemName, rule, classes, itemLink)
-            stmt:step()
-            stmt:reset()
-            LNS.NormalItemsRules[itemID] = rule
-            LNS.NormalItemsClasses[itemID] = classes
-            LNS.ItemNames[itemID] = itemName
-            if itemID > 0 then tmpNormalDB[itemID] = nil end
-        end
-    end
     stmt:finalize()
 
 
@@ -1240,9 +1236,7 @@ item_link = excluded.item_link
 
     -- update our missing tables
     LNS.GlobalItemsMissing = tmpGlobalDB or {}
-    LNS.NormalItemsMissing = tmpNormalDB or {}
     LNS.GlobalMissingNames = tmpNamesGlobal or {}
-    LNS.NormalMissingNames = tmpNamesNormal or {}
 end
 
 return LNS_DB

--- a/modules/settings.lua
+++ b/modules/settings.lua
@@ -6,7 +6,7 @@ LNS_SETTINGS.MyName            = mq.TLO.Me.DisplayName()
 LNS_SETTINGS.EqServer          = string.gsub(mq.TLO.EverQuest.Server(), ' ', '_')
 LNS_SETTINGS.PersonalTableName = string.format("%s_Rules", LNS_SETTINGS.MyName)
 LNS_SETTINGS.TableListRules    = {
-    "Global_Rules", "Normal_Rules", LNS_SETTINGS.PersonalTableName,
+    "Global_Rules", LNS_SETTINGS.PersonalTableName,
 }
 
 -- tables
@@ -59,7 +59,6 @@ LNS_SETTINGS.SettingsEnum      = {
     maxcorpsespercycle = 'MaxCorpsesPerCycle',
     ignorebagslot = 'IgnoreBagSlot',
     processingeval = 'ProcessingEval',
-    alwaysglobal = 'AlwaysGlobal',
     useautorules = 'UseAutoRules',
     trackhistory = 'TrackHistory',
     NavTimeout = 'NavTimeout',
@@ -129,7 +128,6 @@ LNS_SETTINGS.Settings          = {
     ShowReport          = false,
     MaxCorpsesPerCycle  = 5,     -- Maximum number of corpses to loot per cycle
     IgnoreBagSlot       = 0,     -- Ignore this Bag Slot when buying, selling, tributing and destroying of items.
-    AlwaysGlobal        = false, -- Always assign new rules to global as well as normal rules.
     IgnoreMyNearCorpses = false, -- Ignore my own corpses when looting nearby corpses, some servers you spawn after death with all your gear so this setting is handy.
     TrackHistory        = true,  -- Enable inserting loot results into history table
     AlwaysAsk           = false, -- Treat all items as Ask reguardless of their rule.
@@ -140,7 +138,7 @@ LNS_SETTINGS.Settings          = {
 }
 
 LNS_SETTINGS.Tooltips          = {
-    GlobalLootOn        = "Toggle using Global Rules if off we will only use Normal or Personal Rules. This setting is old and will probably be removed in the future.",
+    GlobalLootOn        = "Toggle using Global Rules if off we will only use Personal Rules. This setting is old and will probably be removed in the future.",
     CombatLooting       = "Enables looting during combat. Not recommended on the MT",
     CorpseZRadius       = "Z Radius to activly loot corpses",
     MobsTooClose        = "Don't loot if mobs are in this range.",
@@ -150,7 +148,7 @@ LNS_SETTINGS.Tooltips          = {
     MinSellPrice        = "Minimum Sell price to keep item. -1 = any",
     StackPlatValue      = "Minimum sell value for full stack",
     StackableOnly       = "Only loot stackable items",
-    AlwaysEval          = "Re-Evaluate all *Non Quest* (Normal Item Rules) items. useful to update loot.ini after changing min sell values.",
+    AlwaysEval          = "Re-Evaluate all *Non Quest* (Global Item Rules) items. useful to update loot.ini after changing min sell values.",
     BankTradeskills     = "Toggle flagging Tradeskill items as Bank or not.",
     DoLoot              = "Enable auto looting in standalone mode",
     LootForage          = "Enable Looting of Foraged Items",
@@ -177,17 +175,16 @@ REQUIRES DoDestroy set to true.]],
     AutoTag             = "Automatically tag items to sell if they meet the MinSellPrice",
     AutoRestock         = "Automatically restock items from the BuyItems list after selling",
     LootMyCorpse        = "Loot your own corpse if its nearby (Does not check for REZ)",
-    LootAugments        = "Loot Augments Overrides Normal Rules for Augments, Global and Personal Rules will override this setting",
+    LootAugments        = "Loot Augments Overrides Global Rules for Augments, Personal Rules will override this setting",
     CheckCorpseOnce     = "Check Corpse once and move on. Ignore the next time it is in range if enabled",
     AutoShowNewItem     = "Automatically show new items in the looted window",
-    KeepSpells          = "Keep spells reguardless of Normal Rule Global or Personal Rules will override this setting",
+    KeepSpells          = "Keep spells regardless of Global Rule. Personal Rules will override this setting",
     CanWear             = "(Applies to No Drop New Items) Only loot items you can wear",
     ShowInfoMessages    = "Show or Hide [INFO] Messages in the loot console",
     ShowConsole         = "Show or Hide the Loot Console window",
     ShowReport          = "Prints report to the Console also toggles the report table window open if its closed.",
     IgnoreBagSlot       = "gnore this Bag Slot when buying, selling, tributing and destroying of items.",
     MaxCorpsesPerCycle  = "Maximum number of corpses to loot per cycle.",
-    AlwaysGlobal        = "Always assign new rules to global as well as normal rules.",
     IgnoreMyNearCorpses = "Ignore my own corpses when looting nearby corpses, some servers you spawn after death with all your gear so this setting is handy.",
     TrackHistory        = "Enable inserting loot results into history table",
     AlwaysAsk           = "Treat all items as Ask reguardless of their rule.",

--- a/modules/ui.lua
+++ b/modules/ui.lua
@@ -709,41 +709,6 @@ function LNS_UI.renderMissingItemsTables()
 
         ImGui.EndTable()
     end
-    ImGui.Separator()
-    ImGui.Text("Imported Normal Rules")
-    if ImGui.BeginTable("ImportedData##Normal", 4, bit32.bor(ImGuiTableFlags.ScrollY, ImGuiTableFlags.Borders), ImVec2(0.0, 300)) then
-        ImGui.TableSetupColumn("Item ID##n", ImGuiTableColumnFlags.WidthFixed, 40)
-        ImGui.TableSetupColumn("Item Name##n", ImGuiTableColumnFlags.WidthStretch, 100)
-        ImGui.TableSetupColumn("Item Rule##n", ImGuiTableColumnFlags.WidthFixed, 60)
-        ImGui.TableSetupColumn("Item Classes##n", ImGuiTableColumnFlags.WidthFixed, 60)
-        ImGui.TableHeadersRow()
-        ImGui.TableNextRow()
-
-        for _, v in ipairs(settings.TempSettings.SortedMissingNormalNames or {}) do
-            if LNS.NormalItemsMissing[v.id] ~= nil then
-                ImGui.TableNextColumn()
-                ImGui.TextColored(ImVec4(1.000, 0.557, 0.000, 1.000), "%s", LNS.NormalItemsMissing[v.id].item_id)
-                ImGui.TableNextColumn()
-                ImGui.PushStyleColor(ImGuiCol.Text, ImVec4(0.370, 0.704, 1.000, 1.000))
-                if ImGui.Selectable(string.format("%s", LNS.NormalItemsMissing[v.id].item_name), false) then
-                    settings.TempSettings.ModifyItemRule = true
-                    settings.TempSettings.ModifyItemName = LNS.NormalItemsMissing[v.id].item_name
-                    settings.TempSettings.ModifyItemLink = nil
-                    settings.TempSettings.ModifyItemID = LNS.NormalItemsMissing[v.id].item_id
-                    settings.TempSettings.ModifyItemTable = "Normal_Items"
-                    settings.TempSettings.ModifyClasses = LNS.NormalItemsMissing[v.id].item_classes
-                    settings.TempSettings.ModifyItemSetting = LNS.NormalItemsMissing[v.id].item_rule
-                end
-                ImGui.PopStyleColor()
-                ImGui.TableNextColumn()
-                ImGui.Text(LNS.NormalItemsMissing[v.id].item_rule or 'Unknown')
-                ImGui.TableNextColumn()
-                ImGui.Text(LNS.NormalItemsMissing[v.id].item_classes or 'Unknown')
-            end
-        end
-
-        ImGui.EndTable()
-    end
 end
 
 function LNS_UI.renderImportDBWindow()
@@ -1306,18 +1271,12 @@ function LNS_UI.drawNewItemsTable()
                     -- ImGui.PopStyleVar()
 
                     ImGui.Spacing()
-                    if LNS.tempGlobalRule[itemID] == nil then
-                        LNS.tempGlobalRule[itemID] = settings.Settings.AlwaysGlobal
-                    end
-                    ImGui.Indent(10)
-                    LNS.tempGlobalRule[itemID] = ImGui.Checkbox('Global Rule', LNS.tempGlobalRule[itemID])
-                    ImGui.Unindent(10)
                     ImGui.Indent(35)
                     -- ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (ImGui.GetColumnWidth(-1) / 6))
                     ImGui.PushStyleColor(ImGuiCol.Button, ImVec4(0.040, 0.294, 0.004, 1.000))
                     if ImGui.Button('Save Rule') then
                         local classes = LNS.tempLootAll[itemID] and "All" or tmpClasses[itemID]
-                        local ruleTable = LNS.tempGlobalRule[itemID] and "GlobalItems" or "NormalItems"
+                        local ruleTable = "GlobalItems"
                         LNS.enterNewItemRuleInfo({
                             ID = itemID,
                             RuleType = ruleTable,
@@ -1549,7 +1508,7 @@ function LNS_UI.drawTabbedTable(label)
             ImGui.SameLine()
             ImGui.SetNextItemWidth(100)
             if settings.TempSettings.BulkSetTable == nil then
-                settings.TempSettings.BulkSetTable = label .. "_Rules"
+                settings.TempSettings.BulkSetTable = label == "Personal" and settings.PersonalTableName or "Global_Rules"
             end
             if ImGui.BeginCombo("Table", settings.TempSettings.BulkSetTable) then
                 for i, v in ipairs(settings.TableListRules) do
@@ -1576,6 +1535,13 @@ function LNS_UI.drawTabbedTable(label)
                 end
             end
 
+            if settings.TempSettings.BulkSetTable == settings.PersonalTableName then
+                if LNS.TempBulkSharePersonal == nil then LNS.TempBulkSharePersonal = false end
+                LNS.TempBulkSharePersonal = ImGui.Checkbox("Share to Others##bulktab", LNS.TempBulkSharePersonal)
+                if ImGui.IsItemHovered() then
+                    ImGui.SetTooltip("Also set these personal rules on all other logged-in characters")
+                end
+            end
             ImGui.PushStyleColor(ImGuiCol.Button, ImVec4(0.4, 1.0, 0.4, 0.4))
             if ImGui.Button("Set Selected") then
                 settings.TempSettings.BulkSet = {}
@@ -1596,6 +1562,11 @@ function LNS_UI.drawTabbedTable(label)
                     end
                 end
                 settings.TempSettings.doBulkSet = true
+                if LNS.TempBulkSharePersonal and settings.TempSettings.BulkSetTable == settings.PersonalTableName then
+                    for itemID, data in pairs(settings.TempSettings.BulkSet) do
+                        LNS.sharePersonalRuleToOthers(itemID, data.Rule, settings.TempSettings.BulkClasses, data.Link)
+                    end
+                end
             end
             ImGui.PopStyleColor()
 
@@ -1753,47 +1724,52 @@ function LNS_UI.drawItemsTables()
             end
 
             ImGui.SeparatorText("Add New Item")
-            if ImGui.BeginTable("AddItem", 2, ImGuiTableFlags.Borders) then
-                ImGui.TableSetupColumn("Item", ImGuiTableColumnFlags.WidthFixed, 280)
-                ImGui.TableSetupColumn("Qty", ImGuiTableColumnFlags.WidthFixed, 150)
-                ImGui.TableHeadersRow()
-                ImGui.TableNextRow()
 
-                ImGui.TableNextColumn()
+            ImGui.SetNextItemWidth(200)
+            ImGui.PushID("NewBuyItem")
+            settings.TempSettings.NewBuyItem = ImGui.InputTextWithHint("##BuyItemName", "Item Name",
+                settings.TempSettings.NewBuyItem or '')
+            ImGui.PopID()
+            if ImGui.IsItemHovered() and mq.TLO.Cursor() ~= nil then
+                settings.TempSettings.NewBuyItem = mq.TLO.Cursor()
+                mq.cmdf("/autoinv")
+            end
 
-                ImGui.SetNextItemWidth(150)
-                ImGui.PushID("NewBuyItem")
-                settings.TempSettings.NewBuyItem = ImGui.InputText("New Item##BuyItems", settings.TempSettings.NewBuyItem)
-                ImGui.PopID()
-                if ImGui.IsItemHovered() and mq.TLO.Cursor() ~= nil then
-                    settings.TempSettings.NewBuyItem = mq.TLO.Cursor()
-                    mq.cmdf("/autoinv")
-                end
-                ImGui.SameLine()
-                ImGui.PushStyleColor(ImGuiCol.Button, ImVec4(0.4, 1.0, 0.4, 0.4))
-                if ImGui.SmallButton(Icons.MD_ADD) then
-                    LNS.BuyItemsTable[settings.TempSettings.NewBuyItem] = settings.TempSettings.NewBuyQty
-                    LNS.setBuyItem(settings.TempSettings.NewBuyItem, settings.TempSettings.NewBuyQty)
+            ImGui.SameLine()
+            ImGui.SetNextItemWidth(80)
+            settings.TempSettings.NewBuyQty = ImGui.InputInt("Qty##BuyItems", (settings.TempSettings.NewBuyQty or 1), 1, 50)
+            if settings.TempSettings.NewBuyQty > 1000 then settings.TempSettings.NewBuyQty = 1000 end
+
+            ImGui.SameLine()
+            ImGui.PushStyleColor(ImGuiCol.Button, ImVec4(0.4, 1.0, 0.4, 0.4))
+            if ImGui.SmallButton(Icons.MD_ADD) then
+                local buyName = settings.TempSettings.NewBuyItem
+                local buyQty = settings.TempSettings.NewBuyQty
+                if buyName and buyName ~= '' then
+                    LNS.BuyItemsTable[buyName] = buyQty
+                    LNS.setBuyItem(buyName, buyQty)
                     settings.TempSettings.NeedSave = true
-                    settings.TempSettings.NewBuyItem = ""
-                    settings.TempSettings.NewBuyQty = 1
+                    if LNS.TempShareBuyItem then
+                        LNS.shareBuyItemToOthers(buyName, buyQty)
+                    end
                 end
-                ImGui.PopStyleColor()
+                settings.TempSettings.NewBuyItem = ""
+                settings.TempSettings.NewBuyQty = 1
+            end
+            ImGui.PopStyleColor()
 
-                ImGui.SameLine()
-                ImGui.PushStyleColor(ImGuiCol.Button, ImVec4(1.0, 0.4, 0.4, 0.4))
-                if ImGui.SmallButton(Icons.MD_DELETE_SWEEP) then
-                    settings.TempSettings.NewBuyItem = ""
-                end
-                ImGui.PopStyleColor()
-                ImGui.TableNextColumn()
-                ImGui.SetNextItemWidth(120)
+            ImGui.SameLine()
+            ImGui.PushStyleColor(ImGuiCol.Button, ImVec4(1.0, 0.4, 0.4, 0.4))
+            if ImGui.SmallButton(Icons.MD_DELETE_SWEEP) then
+                settings.TempSettings.NewBuyItem = ""
+            end
+            ImGui.PopStyleColor()
 
-                settings.TempSettings.NewBuyQty = ImGui.InputInt("New Qty##BuyItems", (settings.TempSettings.NewBuyQty or 1),
-                    1, 50)
-                if settings.TempSettings.NewBuyQty > 1000 then settings.TempSettings.NewBuyQty = 1000 end
-
-                ImGui.EndTable()
+            ImGui.SameLine()
+            if LNS.TempShareBuyItem == nil then LNS.TempShareBuyItem = false end
+            LNS.TempShareBuyItem = ImGui.Checkbox("Share to Others##buy", LNS.TempShareBuyItem)
+            if ImGui.IsItemHovered() then
+                ImGui.SetTooltip("Also add buy items on all other logged-in characters")
             end
             ImGui.SeparatorText("Buy Items Table")
             if ImGui.BeginTable("Buy Items", col, bit32.bor(ImGuiTableFlags.Borders, ImGuiTableFlags.ScrollY), ImVec2(0.0, 0.0)) then
@@ -1867,8 +1843,6 @@ function LNS_UI.drawItemsTables()
 
         LNS_UI.drawTabbedTable("Global")
 
-        -- Normal Items
-        LNS_UI.drawTabbedTable("Normal")
 
         -- Missing Items
 
@@ -2092,7 +2066,7 @@ example {hp>=500, name~robe} this will return items with 500 + Hp and has robe i
                     ImGui.SameLine()
                     ImGui.SetNextItemWidth(100)
                     if settings.TempSettings.BulkSetTable == nil then
-                        settings.TempSettings.BulkSetTable = "Normal_Rules"
+                        settings.TempSettings.BulkSetTable = "Global_Rules"
                     end
                     if ImGui.BeginCombo("Table", settings.TempSettings.BulkSetTable) then
                         for i, v in ipairs(settings.TableListRules) do
@@ -2118,6 +2092,13 @@ example {hp>=500, name~robe} this will return items with 500 + Hp and has robe i
                         end
                     end
 
+                    if settings.TempSettings.BulkSetTable == settings.PersonalTableName then
+                        if LNS.TempBulkSharePersonal == nil then LNS.TempBulkSharePersonal = false end
+                        LNS.TempBulkSharePersonal = ImGui.Checkbox("Share to Others##bulk", LNS.TempBulkSharePersonal)
+                        if ImGui.IsItemHovered() then
+                            ImGui.SetTooltip("Also set these personal rules on all other logged-in characters")
+                        end
+                    end
                     ImGui.PushStyleColor(ImGuiCol.Button, ImVec4(0.4, 1.0, 0.4, 0.4))
                     if ImGui.Button("Set Selected") then
                         settings.TempSettings.BulkSet = {}
@@ -2130,6 +2111,11 @@ example {hp>=500, name~robe} this will return items with 500 + Hp and has robe i
                             end
                         end
                         settings.TempSettings.doBulkSet = true
+                        if LNS.TempBulkSharePersonal and settings.TempSettings.BulkSetTable == settings.PersonalTableName then
+                            for itemID, data in pairs(settings.TempSettings.BulkSet) do
+                                LNS.sharePersonalRuleToOthers(itemID, data.Rule, settings.TempSettings.BulkClasses, data.Link)
+                            end
+                        end
                     end
                     ImGui.PopStyleColor()
 
@@ -3138,7 +3124,7 @@ function LNS_UI.RenderModifyItemWindow()
         settings.TempSettings.ModifyItemTable = settings.PersonalTableName
     end
     if settings.TempSettings.ModifyItemTable == nil then
-        settings.TempSettings.ModifyItemTable = settings.TempSettings.LastModTable or 'Normal_Items'
+        settings.TempSettings.ModifyItemTable = settings.TempSettings.LastModTable or 'Global_Items'
     end
     -- local missingTable = settings.TempSettings.ModifyItemTable:gsub("_Items", "")
     local classes = settings.TempSettings.ModifyClasses
@@ -3184,10 +3170,6 @@ function LNS_UI.RenderModifyItemWindow()
         if ImGui.RadioButton("Global Items", settings.TempSettings.ModifyItemTable == "Global_Items") then
             settings.TempSettings.ModifyItemTable = "Global_Items"
         end
-        ImGui.SameLine()
-        if ImGui.RadioButton("Normal Items", settings.TempSettings.ModifyItemTable == "Normal_Items") then
-            settings.TempSettings.ModifyItemTable = "Normal_Items"
-        end
 
         if tempValues.Classes == nil and classes ~= nil then
             tempValues.Classes = classes
@@ -3226,23 +3208,32 @@ function LNS_UI.RenderModifyItemWindow()
             end
         end
 
+        if settings.TempSettings.ModifyItemTable == settings.PersonalTableName then
+            if LNS.TempSharePersonal == nil then LNS.TempSharePersonal = false end
+            LNS.TempSharePersonal = ImGui.Checkbox("Share to Other Characters", LNS.TempSharePersonal)
+            if ImGui.IsItemHovered() then
+                ImGui.SetTooltip("Also set this personal rule on all other logged-in characters")
+            end
+        end
+
         if ImGui.Button("Set Rule") then
             local newRule = tempValues.Rule == "Quest" and questRule or tempValues.Rule
             if tempValues.Classes == nil or tempValues.Classes == '' or LNS.TempModClass then
                 tempValues.Classes = "All"
             end
-            -- loot.modifyItemRule(loot.TempSettings.ModifyItemID, newRule, loot.TempSettings.ModifyItemTable, tempValues.Classes, item.Link)
             if settings.TempSettings.ModifyItemTable == settings.PersonalTableName then
                 LNS.PersonalItemsRules[settings.TempSettings.ModifyItemID] = newRule
                 LNS.setPersonalItem(settings.TempSettings.ModifyItemID, newRule, tempValues.Classes, item.Link)
+                if LNS.TempSharePersonal then
+                    LNS.sharePersonalRuleToOthers(settings.TempSettings.ModifyItemID, newRule, tempValues.Classes, item.Link)
+                end
             elseif settings.TempSettings.ModifyItemTable == "Global_Items" then
                 LNS.GlobalItemsRules[settings.TempSettings.ModifyItemID] = newRule
                 LNS.setGlobalItem(settings.TempSettings.ModifyItemID, newRule, tempValues.Classes, item.Link)
             else
-                LNS.NormalItemsRules[settings.TempSettings.ModifyItemID] = newRule
-                LNS.setNormalItem(settings.TempSettings.ModifyItemID, newRule, tempValues.Classes, item.Link)
+                LNS.GlobalItemsRules[settings.TempSettings.ModifyItemID] = newRule
+                LNS.setGlobalItem(settings.TempSettings.ModifyItemID, newRule, tempValues.Classes, item.Link)
             end
-            -- loot.setNormalItem(loot.TempSettings.ModifyItemID, newRule,  tempValues.Classes, item.Link)
             settings.TempSettings.ModifyItemRule = false
             settings.TempSettings.ModifyItemID = nil
             settings.TempSettings.LastModTable = settings.TempSettings.ModifyItemTable
@@ -3251,6 +3242,7 @@ function LNS_UI.RenderModifyItemWindow()
             settings.TempSettings.ModifyItemName = nil
             settings.TempSettings.ModifyItemLink = nil
             LNS.TempModClass = false
+            LNS.TempSharePersonal = false
             settings.TempSettings.LastModID = 0
             ImGui.End()
             return
@@ -3262,11 +3254,14 @@ function LNS_UI.RenderModifyItemWindow()
             if settings.TempSettings.ModifyItemTable == settings.PersonalTableName then
                 LNS.PersonalItemsRules[settings.TempSettings.ModifyItemID] = nil
                 LNS.setPersonalItem(settings.TempSettings.ModifyItemID, 'delete', 'All', 'NULL')
+                if LNS.TempSharePersonal then
+                    LNS.sharePersonalRuleToOthers(settings.TempSettings.ModifyItemID, 'delete', 'All', 'NULL')
+                end
             elseif settings.TempSettings.ModifyItemTable == "Global_Items" then
                 -- loot.GlobalItemsRules[loot.TempSettings.ModifyItemID] = nil
                 LNS.setGlobalItem(settings.TempSettings.ModifyItemID, 'delete', 'All', 'NULL')
             else
-                LNS.setNormalItem(settings.TempSettings.ModifyItemID, 'delete', 'All', 'NULL')
+                LNS.setGlobalItem(settings.TempSettings.ModifyItemID, 'delete', 'All', 'NULL')
             end
             settings.TempSettings.ModifyItemRule = false
             settings.TempSettings.ModifyItemID = nil
@@ -3275,6 +3270,7 @@ function LNS_UI.RenderModifyItemWindow()
             settings.TempSettings.ModifyItemMatches = nil
             settings.TempSettings.ModifyItemName = nil
             settings.TempSettings.LastModID = 0
+            LNS.TempSharePersonal = false
 
             ImGui.PopStyleColor()
 
@@ -3292,6 +3288,7 @@ function LNS_UI.RenderModifyItemWindow()
             settings.TempSettings.ModifyItemLink = nil
             settings.TempSettings.ModifyItemMatches = nil
             settings.TempSettings.LastModID = 0
+            LNS.TempSharePersonal = false
         end
 
         if settings.TempSettings.ModifyItemMatches ~= nil then
@@ -3340,11 +3337,11 @@ item_link = row.link or 'NULL',
                             LNS.GlobalItemsClasses[oldID] = nil
                             LNS.setGlobalItem(oldID, 'delete', 'All', 'NULL')
                         else
-                            LNS.setNormalItem(id, newRule, tempValues.Classes, LNS.ItemLinks[id])
-                            LNS.NormalItemsMissing[oldID] = nil
-                            LNS.NormalItemsRules[oldID] = nil
-                            LNS.NormalItemsClasses[oldID] = nil
-                            LNS.setNormalItem(oldID, 'delete', 'All', 'NULL')
+                            LNS.setGlobalItem(id, newRule, tempValues.Classes, LNS.ItemLinks[id])
+                            LNS.GlobalItemsMissing[oldID] = nil
+                            LNS.GlobalItemsRules[oldID] = nil
+                            LNS.GlobalItemsClasses[oldID] = nil
+                            LNS.setGlobalItem(oldID, 'delete', 'All', 'NULL')
                         end
 
                         LNS.ItemNames[oldID] = nil


### PR DESCRIPTION
Since Personal rule sets were added, the need for global and normal rule sets became redundant.

Merged the Normal Rules table into the Global rules table, keeping the Global rule on conflicts.

Dropped the Normal Rules table after the migration.

Now we only deal with GLobal rules and Personal Per charcter rules.

Added the ability to share setting items as personal with other characters over actors. this is handy when you outlevel a set of gear and want to change the rule for this group but not the global rule.

added the ability to share setting new buy items with other characters through the gui as well. you could always create them with / commands and use broadcasting to do the same but now its easier in the gui.

added a check for MQ2Nav on startup and will exit with a message if Nav is not running.